### PR TITLE
Edit reshape of mask in pointing game

### DIFF
--- a/quantus/metrics/localisation_metrics.py
+++ b/quantus/metrics/localisation_metrics.py
@@ -145,7 +145,7 @@ class PointingGame(Metric):
 
             # Reshape.
             a = a.flatten()
-            s = s.reshape(self.img_size, self.img_size).flatten().astype(bool)
+            s = s.squeeze().flatten().astype(bool)
 
             if self.abs:
                 a = np.abs(a)


### PR DESCRIPTION
Edit in pointing game where the masks are assumed to be square and reshaped. This can cause problems if the masks are non-square. This edit removes the reshape. Since we are flattening the masks the reshape should not be necessary and the non-square issue should be resolved.