### PR TITLE
minor typo corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Before creating a PR, double-check that the following tasks are completed:
 
 - [x] Run `black` to format source code e.g., `black quantus/helpers/INSERT_YOUR_FILE_NAME.py`
 - [x] Run `flake8` for quick style checks e.g., `flake8 quantus/helpers/INSERT_YOUR_FILE_NAME.py`
-- [x] Make `pytests` and add under `tests/` folder (to install mandatory packages for testing run `pip install -r requirements_text.txt`)
+- [x] Make `pytests` and add under `tests/` folder (to install mandatory packages for testing run `pip install -r requirements_test.txt`)
 - [x] If the `pytests` include a new category of `@pytest.mark` then add that category with description to `pytest.ini`
 - [x] Run `pytest tests -v --cov-report term --cov-report html:htmlcov --cov-report xml --cov=quantus` to inspect that code coverage is maintained (we aim at ~100% code coverage for Quantus)
 

--- a/quantus/metrics/faithfulness_metrics.py
+++ b/quantus/metrics/faithfulness_metrics.py
@@ -986,7 +986,7 @@ class PixelFlipping(Metric):
                 citation=(
                     "Bach, Sebastian, et al. 'On pixel-wise explanations for non-linear classifier"
                     " decisions by layer - wise relevance propagation.' PloS one 10.7 (2015) "
-                    "e0130140."
+                    "e0130140"
                 ),
             )
             warn_attributions(normalise=self.normalise, abs=self.abs)

--- a/quantus/metrics/faithfulness_metrics.py
+++ b/quantus/metrics/faithfulness_metrics.py
@@ -1200,16 +1200,6 @@ class RegionPerturbation(Metric):
         self.patch_size = self.kwargs.get("patch_size", 8)
         self.order = self.kwargs.get("order", "MoRF").lower()
         self.img_size = self.kwargs.get("img_size", 224)
-        self.text_warning = (
-            "\nThe Region perturbation metric is likely to be sensitive to the choice of "
-            "baseline value 'perturb_baseline', the patch size for masking 'patch_size' and number of regions to"
-            " evaluate 'regions_evaluation'. "
-            "\nGo over and select each hyperparameter of the metric carefully to avoid misinterpretation of scores. "
-            "\nTo view all relevant hyperparameters call .get_params of the metric instance. "
-            "\nFor further reading: Samek, Wojciech, et al. 'Evaluating the visualization of what a "
-            "deep neural network has learned.' IEEE transactions on neural networks and learning "
-            "systems 28.11 (2016): 2660-2673.' PloS one 10.7 (2015): e0130140."
-        )
         self.last_results = {}
         self.all_results = []
 
@@ -1218,11 +1208,15 @@ class RegionPerturbation(Metric):
         if not self.disable_warnings:
             warn_parameterisation(
                 metric_name=self.__class__.__name__,
-                sensitive_params=("baseline value 'perturb_baseline'"),
+                sensitive_params=(
+                    "baseline value 'perturb_baseline'"
+                    ", the patch size for masking 'patch_size'"
+                    " and number of regions to evaluate 'regions_evaluation'"
+                ),
                 citation=(
-                    "Bach, Sebastian, et al. 'On pixel-wise explanations for non-linear classifier"
-                    " decisions by layer - wise relevance propagation.' PloS one 10.7 (2015): "
-                    "e0130140"
+                    "Samek, Wojciech, et al. 'Evaluating the visualization of what a deep"
+                    " neural network has learned.' IEEE transactions on neural networks and"
+                    " learning systems 28.11 (2016): 2660-2673"
                 ),
             )
             warn_attributions(normalise=self.normalise, abs=self.abs)

--- a/tutorials/tutorial_basic_example_all_metrics.ipynb
+++ b/tutorials/tutorial_basic_example_all_metrics.ipynb
@@ -956,7 +956,7 @@
       "\n",
       "The Pixel Flipping metric is likely to be sensitive to the choice of baseline value 'perturb_baseline'. \n",
       "To avoid misinterpretation of scores, consider all relevant hyperparameters of the metric (by calling .get_params of the metric instance). \n",
-      "For further reading see Bach, Sebastian, et al. 'On pixel-wise explanations for non-linear classifier decisions by layer - wise relevance propagation.' PloS one 10.7 (2015) e0130140..\n",
+      "For further reading see Bach, Sebastian, et al. 'On pixel-wise explanations for non-linear classifier decisions by layer - wise relevance propagation.' PloS one 10.7 (2015) e0130140.\n",
       "To disable warnings set disable_warnings=True in the initialisation of metric instance.\u001b[0m\n",
       "\n",
       "Normalising attributions may destroy or skew information in the explanation and as a result, affect the overall evaluation outcome.\n",

--- a/tutorials/tutorial_basic_example_all_metrics.ipynb
+++ b/tutorials/tutorial_basic_example_all_metrics.ipynb
@@ -1024,9 +1024,9 @@
      "text": [
       "WARNINGS.\n",
       "\n",
-      "The Region Perturbation metric is likely to be sensitive to the choice of baseline value 'perturb_baseline'. \n",
+      "The Region Perturbation metric is likely to be sensitive to the choice of baseline value 'perturb_baseline', the patch size for masking 'patch_size' and number of regions to evaluate 'regions_evaluation'. \n",
       "To avoid misinterpretation of scores, consider all relevant hyperparameters of the metric (by calling .get_params of the metric instance). \n",
-      "For further reading see Bach, Sebastian, et al. 'On pixel-wise explanations for non-linear classifier decisions by layer - wise relevance propagation.' PloS one 10.7 (2015): e0130140.\n",
+      "For further reading see: Samek, Wojciech, et al. 'Evaluating the visualization of what a deep neural network has learned.' IEEE transactions on neural networks and learning systems 28.11 (2016): 2660-2673.\n",
       "To disable warnings set disable_warnings=True in the initialisation of metric instance.\u001b[0m\n",
       "\n",
       "Normalising attributions may destroy or skew information in the explanation and as a result, affect the overall evaluation outcome.\n",


### PR DESCRIPTION
Apart from a small typo regarding `requirements_test.txt` in the `README.md`, `RegionPerturbation` had a wrong citation. I fixed it both in the python-file and the ipython-notebook.
I subsequently removed the `text_warning` attribute, which was already unused before my changes.
I don't know if the code relevant for this attribute in `attributes_check` and `set_warn` in `asserts.py` is now necessary anymore, but you will definitely know better.