### PR TITLE
Typo: Close brackets in functions' examples

### DIFF
--- a/quantus/metrics/axiomatic_metrics.py
+++ b/quantus/metrics/axiomatic_metrics.py
@@ -139,7 +139,7 @@ class Completeness(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = Completeness(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -339,7 +339,7 @@ class NonSensitivity(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = NonSensitivity(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape# Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -534,7 +534,7 @@ class InputInvariance(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = InputInvariance(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -96,7 +96,7 @@ class Metric:
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = Metric(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         raise NotImplementedError
 

--- a/quantus/metrics/complexity_metrics.py
+++ b/quantus/metrics/complexity_metrics.py
@@ -126,7 +126,7 @@ class Sparseness(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = Sparseness(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -303,7 +303,7 @@ class Complexity(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = Complexity(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -476,7 +476,7 @@ class EffectiveComplexity(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = EffectiveComplexity(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))

--- a/quantus/metrics/faithfulness_metrics.py
+++ b/quantus/metrics/faithfulness_metrics.py
@@ -146,7 +146,7 @@ class FaithfulnessCorrelation(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = FaithfulnessCorrelation(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -371,7 +371,7 @@ class FaithfulnessEstimate(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = FaithfulnessEstimate(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -596,7 +596,7 @@ class MonotonicityArya(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = MonotonicityArya(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -819,7 +819,7 @@ class MonotonicityNguyen(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = MonotonicityNguyen(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -1055,7 +1055,7 @@ class PixelFlipping(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = PixelFlipping(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -1281,7 +1281,7 @@ class RegionPerturbation(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = RegionPerturbation(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
 
         # Reshape input batch to channel first order:
@@ -1578,7 +1578,7 @@ class Selectivity(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = Selectivity(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -1871,7 +1871,7 @@ class SensitivityN(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = SensitivityN(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -2105,7 +2105,7 @@ class IterativeRemovalOfFeatures(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = IROF(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))

--- a/quantus/metrics/localisation_metrics.py
+++ b/quantus/metrics/localisation_metrics.py
@@ -129,7 +129,7 @@ class PointingGame(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = PointingGame(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -320,7 +320,7 @@ class AttributionLocalisation(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = AttributionLocalisation(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -530,7 +530,7 @@ class TopKIntersection(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = TopKIntersection(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -714,7 +714,7 @@ class RelevanceRankAccuracy(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = RelevanceRankAccuracy(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -901,7 +901,7 @@ class RelevanceMassAccuracy(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = RelevanceMassAccuracy(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))

--- a/quantus/metrics/randomisation_metrics.py
+++ b/quantus/metrics/randomisation_metrics.py
@@ -133,7 +133,7 @@ class ModelParameterRandomisation(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = ModelParameterRandomisation(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -310,7 +310,7 @@ class RandomLogit(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = RandomLogit(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))

--- a/quantus/metrics/robustness_metrics.py
+++ b/quantus/metrics/robustness_metrics.py
@@ -148,7 +148,7 @@ class LocalLipschitzEstimate(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = LocalLipschitzEstimate(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -357,7 +357,7 @@ class MaxSensitivity(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = MaxSensitivity(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -567,7 +567,7 @@ class AvgSensitivity(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = AvgSensitivity(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))
@@ -779,7 +779,7 @@ class Continuity(Metric):
 
             # Initialise the metric and evaluate explanations by calling the metric instance.
             >> metric = Continuity(abs=True, normalise=False)
-            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{}}
+            >> scores = metric(model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch_saliency, **{})
         """
         # Reshape input batch to channel first order:
         self.channel_first = kwargs.get("channel_first", get_channel_first(x_batch))


### PR DESCRIPTION
Replace closing curly bracket by round bracket.