### PR TITLE
Added a random uniform explanation method

### DIFF
--- a/quantus/helpers/explanation_func.py
+++ b/quantus/helpers/explanation_func.py
@@ -341,6 +341,9 @@ def generate_captum_explanation(
                 # .reshape(kwargs.get("img_size", 224), kwargs.get("img_size", 224))
             )
 
+    elif method == "Control Var. Random Uniform".lower():
+        explanation = torch.rand(size=(inputs.shape[0], *inputs.shape[2:]))
+
     elif method == "Control Var. Constant".lower():
         assert (
             "constant_value" in kwargs

--- a/tests/helpers/test_explanation_func.py
+++ b/tests/helpers/test_explanation_func.py
@@ -328,6 +328,22 @@ else:
             {"value": 0.0},
         ),
         (
+            lazy_fixture("load_mnist_model"),
+            lazy_fixture("load_mnist_images"),
+            {
+                "method": "Control Var. Random Uniform",
+            },
+            {"min": 0.0, "max": 1.0},
+        ),
+        (
+            lazy_fixture("load_1d_3ch_conv_model"),
+            lazy_fixture("almost_uniform_1d_no_abatch"),
+            {
+                "method": "Control Var. Random Uniform",
+            },
+            {"min": 0.0, "max": 1.0},
+        ),
+        (
             lazy_fixture("load_1d_3ch_conv_model"),
             lazy_fixture("almost_uniform_1d_no_abatch"),
             {


### PR DESCRIPTION
Having a baseline explanation that you know should be "bad" can in many cases be a good sanity check. The current baselines 'Control Var. Constant' and 'Control Var. Sobel Filter', can run into problems for perturbation-based metrics, since they often don't change under perturbation. The baseline added in this PR is simply a random explanation sample from U(0, 1), entitled 'Control Var. Random Uniform'.