### PR TITLE
Typo: Correct acronym for AUC

### DIFF
--- a/quantus/metrics/faithfulness_metrics.py
+++ b/quantus/metrics/faithfulness_metrics.py
@@ -1432,7 +1432,7 @@ class PixelFlipping(Metric):
 
     @property
     def get_auc_score(self):
-        """Calculate the area under the curve (AOC) score for several test samples."""
+        """Calculate the area under the curve (AUC) score for several test samples."""
         return [np.trapz(np.array(results), dx=1.0) for results in self.all_results]
 
 class RegionPerturbation(Metric):
@@ -1727,7 +1727,7 @@ class RegionPerturbation(Metric):
 
     @property
     def get_auc_score(self):
-        """Calculate the area under the curve (AOC) score for several test samples."""
+        """Calculate the area under the curve (AUC) score for several test samples."""
         return [np.trapz(np.array(result), dx=1.0) for results in self.all_results for _, result in results.items()]
 
 
@@ -1993,7 +1993,7 @@ class Selectivity(Metric):
 
     @property
     def get_auc_score(self):
-        """Calculate the area under the curve (AOC) score for several test samples."""
+        """Calculate the area under the curve (AUC) score for several test samples."""
         return [np.trapz(np.array(result), dx=1.0) for results in self.all_results for _, result in results.items()]
 
 


### PR DESCRIPTION
The acronym for Area Under the Curve is AUC, not AOC.

On a side note, the function `get_auc_score` should be refactored to be defined only once and, thus, avoid code repetition.
Also, not sure why it has two different definitions. If this is indeed needed, it should be documented in the function's docstring.