### PR TITLE
improve error message for missing `"gc_layer"` kwarg when using `quantus.explain(..., method="GradCAM")`

### DIFF
--- a/quantus/helpers/explanation_func.py
+++ b/quantus/helpers/explanation_func.py
@@ -323,7 +323,7 @@ def generate_captum_explanation(
     elif method == "GradCam".lower():
         if "gc_layer" not in kwargs:
             raise ValueError(
-                "Provide kwargs, 'gc_layer' e.g., list(model.named_modules())[1][1][-6] to run GradCam."
+                "Provide kwargs, 'gc_layer' e.g., list(model.named_modules())[-4][1] to run GradCam."
             )
 
         if isinstance(kwargs["gc_layer"], str):


### PR DESCRIPTION
The previous error message, ending with "-6" indexing, suggested there are more than 6 indices, while `model.named_modules()` returns 2-tuples of `(layer_name, nn.Module)`, or blocks of such. Hence, I think the example is easier to understand with [1]-index at the end, suggesting to take the `nn.Module`. 
This example takes the last conv2-layer of `torchvision.models.resnet18`.