### PR TITLE
Require `numpy>=1.19.5` for correct version solving

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 coverage==6.2
 flake8==4.0.1
 matplotlib==3.3.4
-numpy==1.19.5
+numpy>=1.19.5
 opencv-python==4.5.5.62
 protobuf~=3.19.0
 pytest==6.2.5


### PR DESCRIPTION
Poetry version solving currently fails at `poetry add quantus` because:
`opencv-python (4.5.5.62)` depends on `numpy (>=1.21.2)` and Quantus has locked `numpy==1.19.5`.

Instead, replacing `==` with `>=` solves the issue.