### PR TITLE
bug: tensorflow is required, even if not used

### DIFF
--- a/quantus/helpers/utils.py
+++ b/quantus/helpers/utils.py
@@ -299,21 +299,23 @@ def get_wrapped_model(
     -------
     model (ModelInterface): A wrapped ModelInterface model.
     """
-    if isinstance(model, tf.keras.Model):
-        return TensorFlowModel(
-            model=model,
-            channel_first=channel_first,
-            softmax=softmax,
-            predict_kwargs=predict_kwargs,
-        )
-    if isinstance(model, torch.nn.modules.module.Module):
-        return PyTorchModel(
-            model=model,
-            channel_first=channel_first,
-            softmax=softmax,
-            device=device,
-            predict_kwargs=predict_kwargs,
-        )
+    if util.find_spec("tensorflow"):
+        if isinstance(model, tf.keras.Model):
+            return TensorFlowModel(
+                model=model,
+                channel_first=channel_first,
+                softmax=softmax,
+                predict_kwargs=predict_kwargs,
+            )
+    if util.find_spec("torch"):
+        if isinstance(model, torch.nn.modules.module.Module):
+            return PyTorchModel(
+                model=model,
+                channel_first=channel_first,
+                softmax=softmax,
+                device=device,
+                predict_kwargs=predict_kwargs,
+            )
     raise ValueError(
         "Model needs to be tf.keras.Model or torch.nn.modules.module.Module."
     )


### PR DESCRIPTION
This is a quick-fix to the problem that when tensorflow isn't installed, running the line `if isinstance(model, tf.keras.Model)`
gives the following error:
`NameError: name 'tf' is not defined`