### PR TITLE
Feature/handle changes in predictions robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ build/
 # tutorials
 tutorials/sample_data/
 tutorials/invited_talks/
+
+# PyCharm project files
+.idea

--- a/docs/developer_notes.md
+++ b/docs/developer_notes.md
@@ -3,6 +3,7 @@ Read more here: https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html and 
 ```bash
 $ cd docs
 $ make clean
+$ pip install -r requirements_sphinx.txt
 $ sphinx-apidoc -o source/docs_api ../quantus --module-first -f --separate
 $ make html
 ```

--- a/docs/source/docs_api/quantus.functions.handle_prediction_change_func.rst
+++ b/docs/source/docs_api/quantus.functions.handle_prediction_change_func.rst
@@ -1,0 +1,7 @@
+quantus.functions.handle\_prediction\_change\_func module
+=========================================================
+
+.. automodule:: quantus.functions.handle_prediction_change_func
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/docs_api/quantus.functions.rst
+++ b/docs/source/docs_api/quantus.functions.rst
@@ -14,6 +14,7 @@ Submodules
 
    quantus.functions.discretise_func
    quantus.functions.explanation_func
+   quantus.functions.handle_prediction_change_func
    quantus.functions.loss_func
    quantus.functions.mosaic_func
    quantus.functions.norm_func

--- a/quantus/functions/handle_prediction_change_func.py
+++ b/quantus/functions/handle_prediction_change_func.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+import numpy as np
+
+from typing import TYPE_CHECKING
+import warnings
+
+if TYPE_CHECKING:
+    from quantus.helpers.model.model_interface import ModelInterface
+
+
+def raise_exception_on_prediction_change(model: ModelInterface, x_batch: np.ndarray, x_batch_perturbed: np.ndarray):
+    is_batched = len(x_batch.shape) == 4
+    if not is_batched:
+        x_batch = np.expand_dims(x_batch, 0)
+        x_batch_perturbed = np.expand_dims(x_batch_perturbed, 0)
+
+    y_batch = model.predict(x_batch).argmax(axis=1)
+    y_batch_perturbed = model.predict(x_batch_perturbed).argmax(axis=1)
+    indexes_of_changed_labels = np.argwhere(y_batch != y_batch_perturbed).reshape(-1)
+    if len(indexes_of_changed_labels) != 0:
+        raise ValueError("Perturbation caused change in prediction.")
+
+
+def warn_on_prediction_change(model: ModelInterface, x_batch: np.ndarray, x_batch_perturbed: np.ndarray) -> np.ndarray:
+    is_batched = len(x_batch.shape) == 4
+    if not is_batched:
+        x_batch = np.expand_dims(x_batch, 0)
+        x_batch_perturbed = np.expand_dims(x_batch_perturbed, 0)
+
+    y_batch = model.predict(x_batch).argmax(axis=1)
+    y_batch_perturbed = model.predict(x_batch_perturbed).argmax(axis=1)
+    indexes_of_changed_labels = np.argwhere(y_batch != y_batch_perturbed).reshape(-1)
+    if len(indexes_of_changed_labels) != 0:
+        warnings.warn(f"Perturbation caused change in predictions for indexes {indexes_of_changed_labels}")
+    return x_batch_perturbed if is_batched else x_batch_perturbed[0]
+
+
+def return_nan_on_prediction_change(model: ModelInterface, x_batch: np.ndarray, x_batch_perturbed: np.ndarray) -> np.ndarray:
+    is_batched = len(x_batch.shape) == 4
+    if not is_batched:
+        x_batch = np.expand_dims(x_batch, 0)
+        x_batch_perturbed = np.expand_dims(x_batch_perturbed, 0)
+
+    y_batch = model.predict(x_batch).argmax(axis=1)
+    y_batch_perturbed = model.predict(x_batch_perturbed).argmax(axis=1)
+    indexes_of_changed_labels = np.argwhere(y_batch != y_batch_perturbed).reshape(-1)
+    for i in indexes_of_changed_labels:
+        x_batch_perturbed[i] = np.nan
+    return x_batch_perturbed if is_batched else x_batch_perturbed[0]
+
+
+def ignore_change_in_predictions(model: ModelInterface, x_batch: np.ndarray, x_batch_perturbed: np.ndarray) -> np.ndarray:
+    return x_batch_perturbed

--- a/quantus/functions/handle_prediction_change_func.py
+++ b/quantus/functions/handle_prediction_change_func.py
@@ -8,7 +8,28 @@ if TYPE_CHECKING:
     from quantus.helpers.model.model_interface import ModelInterface
 
 
-def raise_exception_on_prediction_change(model: ModelInterface, x_batch: np.ndarray, x_batch_perturbed: np.ndarray):
+def raise_exception_on_prediction_change(
+    model: ModelInterface, x_batch: np.ndarray, x_batch_perturbed: np.ndarray
+):
+    """
+    Raises ValueError in case prediction changed after applying perturbation to x_batch.
+
+    Parameters
+    ----------
+    model: quantus.ModelInterface
+        Model used to predict labels.
+    x_batch: np.ndarray
+        Batch of images.
+    x_batch_perturbed: np.ndarray
+        Batched of perturbed images.
+
+    Returns
+    -------
+
+    x_batch_perturbed: np.ndarray
+        Batched of perturbed images, if prediction didn't change, otherwise raise exception.
+
+    """
     is_batched = len(x_batch.shape) == 4
     if not is_batched:
         x_batch = np.expand_dims(x_batch, 0)
@@ -19,9 +40,31 @@ def raise_exception_on_prediction_change(model: ModelInterface, x_batch: np.ndar
     indexes_of_changed_labels = np.argwhere(y_batch != y_batch_perturbed).reshape(-1)
     if len(indexes_of_changed_labels) != 0:
         raise ValueError("Perturbation caused change in prediction.")
+    return x_batch_perturbed if is_batched else x_batch_perturbed[0]
 
 
-def warn_on_prediction_change(model: ModelInterface, x_batch: np.ndarray, x_batch_perturbed: np.ndarray) -> np.ndarray:
+def warn_on_prediction_change(
+    model: ModelInterface, x_batch: np.ndarray, x_batch_perturbed: np.ndarray
+) -> np.ndarray:
+    """
+    Prints warning in case prediction changed after applying perturbation to x_batch.
+
+    Parameters
+    ----------
+    model: quantus.ModelInterface
+        Model used to predict labels.
+    x_batch: np.ndarray
+        Batch of images.
+    x_batch_perturbed: np.ndarray
+        Batched of perturbed images.
+
+    Returns
+    -------
+
+    x_batch_perturbed: np.ndarray
+        Batched of perturbed images.
+
+    """
     is_batched = len(x_batch.shape) == 4
     if not is_batched:
         x_batch = np.expand_dims(x_batch, 0)
@@ -31,12 +74,36 @@ def warn_on_prediction_change(model: ModelInterface, x_batch: np.ndarray, x_batc
     y_batch_perturbed = model.predict(x_batch_perturbed).argmax(axis=1)
     indexes_of_changed_labels = np.argwhere(y_batch != y_batch_perturbed).reshape(-1)
     if len(indexes_of_changed_labels) != 0:
-        warnings.warn(f"Perturbation caused change in predictions for indexes {indexes_of_changed_labels}")
+        warnings.warn(
+            f"Perturbation caused change in predictions for indexes {indexes_of_changed_labels}"
+        )
     return x_batch_perturbed if is_batched else x_batch_perturbed[0]
 
 
-def return_nan_on_prediction_change(model: ModelInterface, x_batch: np.ndarray, x_batch_perturbed: np.ndarray) -> np.ndarray:
+def return_nan_on_prediction_change(
+    model: ModelInterface, x_batch: np.ndarray, x_batch_perturbed: np.ndarray
+) -> np.ndarray:
+    """
+    Replaces images for which predictions changed with nan's.
+
+    Parameters
+    ----------
+    model: quantus.ModelInterface
+        Model used to predict labels.
+    x_batch: np.ndarray
+        Batch of images.
+    x_batch_perturbed: np.ndarray
+        Batched of perturbed images.
+
+    Returns
+    -------
+
+    x_batch_perturbed: np.ndarray
+        Batched of perturbed images, where images for which prediction changes are replaced by nan's.
+
+    """
     is_batched = len(x_batch.shape) == 4
+    img_shape = x_batch.shape[1:]
     if not is_batched:
         x_batch = np.expand_dims(x_batch, 0)
         x_batch_perturbed = np.expand_dims(x_batch_perturbed, 0)
@@ -45,9 +112,30 @@ def return_nan_on_prediction_change(model: ModelInterface, x_batch: np.ndarray, 
     y_batch_perturbed = model.predict(x_batch_perturbed).argmax(axis=1)
     indexes_of_changed_labels = np.argwhere(y_batch != y_batch_perturbed).reshape(-1)
     for i in indexes_of_changed_labels:
-        x_batch_perturbed[i] = np.nan
+        x_batch_perturbed[i] = np.full(fill_value=np.nan, shape=img_shape)
     return x_batch_perturbed if is_batched else x_batch_perturbed[0]
 
 
-def ignore_change_in_predictions(model: ModelInterface, x_batch: np.ndarray, x_batch_perturbed: np.ndarray) -> np.ndarray:
+def ignore_change_in_predictions(
+    model: ModelInterface, x_batch: np.ndarray, x_batch_perturbed: np.ndarray
+) -> np.ndarray:
+    """
+    Does nothing.
+
+    Parameters
+    ----------
+    model: quantus.ModelInterface
+        Unused.
+    x_batch: np.ndarray
+        Unused.
+    x_batch_perturbed: np.ndarray
+        Unused.
+
+    Returns
+    -------
+
+    x_batch_perturbed: np.ndarray
+        Batched of perturbed images.
+
+    """
     return x_batch_perturbed

--- a/quantus/helpers/constants.py
+++ b/quantus/helpers/constants.py
@@ -14,6 +14,12 @@ from quantus.functions.normalise_func import *
 from quantus.functions.perturb_func import *
 from quantus.functions.similarity_func import *
 from quantus.metrics import *
+from quantus.functions.handle_prediction_change_func import (
+    warn_on_prediction_change,
+    ignore_change_in_predictions,
+    raise_exception_on_prediction_change,
+    return_nan_on_prediction_change
+)
 
 
 AVAILABLE_METRICS = {
@@ -113,6 +119,15 @@ AVAILABLE_XAI_METHODS = [
     "Control Var. Constant",
     "Control Var. Random Uniform",
 ]
+
+
+PREDICTION_CHANGE_HANDLING_STRATEGIES = {
+    "ReturnNan": return_nan_on_prediction_change,
+    "Ignore": ignore_change_in_predictions,
+    "RaiseException": raise_exception_on_prediction_change,
+    "Warn": warn_on_prediction_change
+}
+
 
 
 def available_categories() -> List[str]:

--- a/quantus/helpers/model/model_interface.py
+++ b/quantus/helpers/model/model_interface.py
@@ -47,7 +47,7 @@ class ModelInterface(ABC):
             self.model_predict_kwargs = model_predict_kwargs
 
     @abstractmethod
-    def predict(self, x: np.array, **kwargs):
+    def predict(self, x: np.array, **kwargs) -> np.ndarray:
         """
         Predict on the given input.
 

--- a/quantus/helpers/utils.py
+++ b/quantus/helpers/utils.py
@@ -6,16 +6,19 @@
 # You should have received a copy of the GNU Lesser General Public License along with Quantus. If not, see <https://www.gnu.org/licenses/>.
 # Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
 
+from __future__ import annotations
+
 import copy
 import re
 from importlib import util
-from typing import Any, Dict, Optional, Sequence, Tuple, Union, List
+from typing import Any, Dict, Optional, Sequence, Tuple, Union, List, Callable
 
 import numpy as np
 from skimage.segmentation import slic, felzenszwalb
 
 from quantus.helpers import asserts
 from quantus.helpers.model.model_interface import ModelInterface
+from quantus.helpers.constants import PREDICTION_CHANGE_HANDLING_STRATEGIES
 
 if util.find_spec("torch"):
     import torch
@@ -986,3 +989,10 @@ def calculate_auc(values: np.array, dx: int = 1):
         Definite integral of values.
     """
     return np.trapz(np.array(values), dx=dx)
+
+
+
+def map_strategy_to_function(strategy: str | Callable[[ModelInterface, np.ndarray, np.ndarray], np.ndarray]) -> Callable[[ModelInterface, np.ndarray, np.ndarray], np.ndarray]:
+    if isinstance(strategy, Callable):
+        return strategy
+    return PREDICTION_CHANGE_HANDLING_STRATEGIES[strategy]

--- a/quantus/helpers/utils.py
+++ b/quantus/helpers/utils.py
@@ -990,9 +990,27 @@ def calculate_auc(values: np.array, dx: int = 1):
     return np.trapz(np.array(values), dx=dx)
 
 
+def map_strategy_to_function(
+    strategy: str | Callable[[ModelInterface, np.ndarray, np.ndarray], np.ndarray]
+) -> Callable[[ModelInterface, np.ndarray, np.ndarray], np.ndarray]:
+    """
+    Lookup handler function by string, or use user provided one.
 
-def map_strategy_to_function(strategy: str | Callable[[ModelInterface, np.ndarray, np.ndarray], np.ndarray]) -> Callable[[ModelInterface, np.ndarray, np.ndarray], np.ndarray]:
+    Parameters
+    ----------
+    strategy: str or Callable[[ModelInterface, np.ndarray, np.ndarray], np.ndarray]
+        Name of strategy as defined in quantus.helpers.constants.PREDICTION_CHANGE_HANDLING_STRATEGIES or a Callable matching provided signature.
+
+    Returns
+    -------
+    function: Callable[[ModelInterface, np.ndarray, np.ndarray], np.ndarray]
+        Function used to handle changes in predictions.
+
+    """
     if isinstance(strategy, Callable):
         return strategy
+
+    # Importing this at top level leads to circular imports.
     from quantus.helpers.constants import PREDICTION_CHANGE_HANDLING_STRATEGIES
+
     return PREDICTION_CHANGE_HANDLING_STRATEGIES[strategy]

--- a/quantus/helpers/utils.py
+++ b/quantus/helpers/utils.py
@@ -18,7 +18,6 @@ from skimage.segmentation import slic, felzenszwalb
 
 from quantus.helpers import asserts
 from quantus.helpers.model.model_interface import ModelInterface
-from quantus.helpers.constants import PREDICTION_CHANGE_HANDLING_STRATEGIES
 
 if util.find_spec("torch"):
     import torch
@@ -995,4 +994,5 @@ def calculate_auc(values: np.array, dx: int = 1):
 def map_strategy_to_function(strategy: str | Callable[[ModelInterface, np.ndarray, np.ndarray], np.ndarray]) -> Callable[[ModelInterface, np.ndarray, np.ndarray], np.ndarray]:
     if isinstance(strategy, Callable):
         return strategy
+    from quantus.helpers.constants import PREDICTION_CHANGE_HANDLING_STRATEGIES
     return PREDICTION_CHANGE_HANDLING_STRATEGIES[strategy]

--- a/quantus/metrics/robustness/avg_sensitivity.py
+++ b/quantus/metrics/robustness/avg_sensitivity.py
@@ -6,7 +6,9 @@
 # You should have received a copy of the GNU Lesser General Public License along with Quantus. If not, see <https://www.gnu.org/licenses/>.
 # Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional
 import numpy as np
 
 from quantus.helpers import asserts
@@ -17,6 +19,7 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.functions.similarity_func import difference
 from quantus.metrics.base_batched import BatchedPerturbationMetric
+from quantus.helpers.utils import map_strategy_to_function
 
 
 class AvgSensitivity(BatchedPerturbationMetric):
@@ -53,6 +56,7 @@ class AvgSensitivity(BatchedPerturbationMetric):
         default_plot_func: Optional[Callable] = None,
         disable_warnings: bool = False,
         display_progressbar: bool = False,
+        prediction_change_handling: str | Callable[[ModelInterface, np.ndarray, np.ndarray], np.ndarray] = "Ignore",
         **kwargs,
     ):
         """
@@ -95,6 +99,9 @@ class AvgSensitivity(BatchedPerturbationMetric):
             Indicates whether the warnings are printed, default=False.
         display_progressbar: boolean
             Indicates whether a tqdm-progress-bar is printed, default=False.
+        prediction_change_handling: quantus.types.PredictionChangeHandlingStrategy or PredictionChangeHandler, optional.
+            Typically, during robustness evaluation one would want predictions to stay the same. This argument specifies what
+            should be done, if this is not the case. Default is noop.
         kwargs: optional
             Keyword arguments.
         """
@@ -138,6 +145,8 @@ class AvgSensitivity(BatchedPerturbationMetric):
         if norm_denominator is None:
             norm_denominator = norm_func.fro_norm
         self.norm_denominator = norm_denominator
+
+        self.prediction_change_handler = map_strategy_to_function(prediction_change_handling)
 
         # Asserts and warnings.
         if not self.disable_warnings:
@@ -306,6 +315,10 @@ class AvgSensitivity(BatchedPerturbationMetric):
                 arr=x_batch,
                 **self.perturb_func_kwargs,
             )
+
+            x_perturbed = self.prediction_change_handler(model, x_batch, x_perturbed)
+
+            x_perturbed = self.prediction_change_handler(model, x_batch, x_perturbed)
 
             x_input = model.shape_input(
                 x=x_perturbed,

--- a/quantus/metrics/robustness/local_lipschitz_estimate.py
+++ b/quantus/metrics/robustness/local_lipschitz_estimate.py
@@ -1,4 +1,5 @@
 """This module contains the implementation of the Local Lipschitz Estimate metric."""
+from __future__ import annotations
 
 # This file is part of Quantus.
 # Quantus is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -6,7 +7,7 @@
 # You should have received a copy of the GNU Lesser General Public License along with Quantus. If not, see <https://www.gnu.org/licenses/>.
 # Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional
 import numpy as np
 
 from quantus.helpers import asserts
@@ -16,6 +17,7 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import gaussian_noise, perturb_batch
 from quantus.functions.similarity_func import lipschitz_constant, distance_euclidean
 from quantus.metrics.base_batched import BatchedPerturbationMetric
+from quantus.helpers.utils import map_strategy_to_function
 
 
 class LocalLipschitzEstimate(BatchedPerturbationMetric):
@@ -55,6 +57,7 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
         default_plot_func: Optional[Callable] = None,
         disable_warnings: bool = False,
         display_progressbar: bool = False,
+        prediction_change_handling: str | Callable[[ModelInterface, np.ndarray, np.ndarray], np.ndarray] = "Ignore",
         **kwargs,
     ):
         """
@@ -99,6 +102,9 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
             Indicates whether the warnings are printed, default=False.
         display_progressbar: boolean
             Indicates whether a tqdm-progress-bar is printed, default=False.
+        prediction_change_handling: quantus.types.PredictionChangeHandlingStrategy or PredictionChangeHandler, optional.
+            Typically, during robustness evaluation one would want predictions to stay the same. This argument specifies what
+            should be done, if this is not the case. Default is noop.
         kwargs: optional
             Keyword arguments.
         """
@@ -142,6 +148,9 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
         if norm_denominator is None:
             norm_denominator = distance_euclidean
         self.norm_denominator = norm_denominator
+
+
+        self.prediction_change_handler = map_strategy_to_function(prediction_change_handling)
 
         # Asserts and warnings.
         if not self.disable_warnings:
@@ -314,6 +323,8 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
                 arr=x_batch,
                 **self.perturb_func_kwargs,
             )
+
+            x_perturbed = self.prediction_change_handler(model, x_batch, x_perturbed)
 
             x_input = model.shape_input(
                 x=x_perturbed,


### PR DESCRIPTION
### Description
- Typically, when evaluation robustness, we want prediction to stay the same. 

### Implemented changes
  - [ ] Added parameter, which allows configuring, how changes in prediction should be handled. Default noop.
  - [ ] Added function with few possible handling options.
  - [ ] Added Notebook showcasing how this feature can be used

### Minimum acceptance criteria
- No breaking changes are introduced.
