### PR TITLE
Validate predictions change robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ build/
 # tutorials
 tutorials/sample_data/
 tutorials/invited_talks/
+
+# PyCharm project files
+.idea

--- a/quantus/metrics/robustness/avg_sensitivity.py
+++ b/quantus/metrics/robustness/avg_sensitivity.py
@@ -53,6 +53,7 @@ class AvgSensitivity(BatchedPerturbationMetric):
         default_plot_func: Optional[Callable] = None,
         disable_warnings: bool = False,
         display_progressbar: bool = False,
+        return_nan_when_prediction_changes: bool = False,
         **kwargs,
     ):
         """
@@ -95,6 +96,8 @@ class AvgSensitivity(BatchedPerturbationMetric):
             Indicates whether the warnings are printed, default=False.
         display_progressbar: boolean
             Indicates whether a tqdm-progress-bar is printed, default=False.
+        return_nan_when_prediction_changes: boolean
+            When set to true, metric will be evaluated to NaN in case prediction changes after perturbation applied.
         kwargs: optional
             Keyword arguments.
         """
@@ -138,6 +141,8 @@ class AvgSensitivity(BatchedPerturbationMetric):
         if norm_denominator is None:
             norm_denominator = norm_func.fro_norm
         self.norm_denominator = norm_denominator
+
+        self.return_nan_when_prediction_changes = return_nan_when_prediction_changes
 
         # Asserts and warnings.
         if not self.disable_warnings:
@@ -307,6 +312,10 @@ class AvgSensitivity(BatchedPerturbationMetric):
                 **self.perturb_func_kwargs,
             )
 
+            changed_prediction_indexes = np.argwhere(
+                model.predict(x_batch).argmax(axis=-1) != model.predict(x_perturbed).argmax(axis=-1)
+            ).reshape(-1)
+
             x_input = model.shape_input(
                 x=x_perturbed,
                 shape=x_batch.shape,
@@ -339,6 +348,11 @@ class AvgSensitivity(BatchedPerturbationMetric):
 
             # Measure similarity for each instance separately.
             for instance_id in range(batch_size):
+
+                if self.return_nan_when_prediction_changes and instance_id in changed_prediction_indexes:
+                    similarities[instance_id, step_id] = np.nan
+                    continue
+
                 sensitivities = self.similarity_func(
                     a=a_batch[instance_id].flatten(),
                     b=a_perturbed[instance_id].flatten(),
@@ -348,7 +362,7 @@ class AvgSensitivity(BatchedPerturbationMetric):
                 sensitivities_norm = numerator / denominator
                 similarities[instance_id, step_id] = sensitivities_norm
 
-        return np.nanmean(similarities, axis=1)
+        return np.mean(similarities, axis=1)
 
     def custom_preprocess(
         self,

--- a/quantus/metrics/robustness/avg_sensitivity.py
+++ b/quantus/metrics/robustness/avg_sensitivity.py
@@ -6,7 +6,7 @@
 # You should have received a copy of the GNU Lesser General Public License along with Quantus. If not, see <https://www.gnu.org/licenses/>.
 # Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional
 import numpy as np
 
 from quantus.helpers import asserts

--- a/quantus/metrics/robustness/consistency.py
+++ b/quantus/metrics/robustness/consistency.py
@@ -62,15 +62,10 @@ class Consistency(Metric):
             If normalise_func=None, the default value is used, default=normalise_by_max.
         normalise_func_kwargs: dict
             Keyword arguments to be passed to normalise_func on call, default={}.
-        perturb_func: callable
-            Input perturbation function. If None, the default value is used,
-            default=gaussian_noise.
         perturb_std: float
             The amount of noise added, default=0.1.
         perturb_mean: float
             The mean of noise added, default=0.0.
-        perturb_func_kwargs: dict
-            Keyword arguments to be passed to perturb_func, default={}.
         return_aggregate: boolean
             Indicates if an aggregated score should be computed over all instances.
         aggregate_func: callable

--- a/quantus/metrics/robustness/consistency.py
+++ b/quantus/metrics/robustness/consistency.py
@@ -6,7 +6,7 @@
 # You should have received a copy of the GNU Lesser General Public License along with Quantus. If not, see <https://www.gnu.org/licenses/>.
 # Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional
 import numpy as np
 
 from quantus.helpers import asserts

--- a/quantus/metrics/robustness/continuity.py
+++ b/quantus/metrics/robustness/continuity.py
@@ -57,6 +57,7 @@ class Continuity(PerturbationMetric):
         default_plot_func: Optional[Callable] = None,
         disable_warnings: bool = False,
         display_progressbar: bool = False,
+        return_nan_when_prediction_changes: bool = False,
         **kwargs,
     ):
         """
@@ -98,6 +99,8 @@ class Continuity(PerturbationMetric):
             Indicates whether a tqdm-progress-bar is printed, default=False.
         default_plot_func: callable
             Callable that plots the metrics result.
+        return_nan_when_prediction_changes: boolean
+            When set to true, metric will be evaluated to NaN in case prediction changes after perturbation applied.
         kwargs: optional
             Keyword arguments.
         """
@@ -134,6 +137,8 @@ class Continuity(PerturbationMetric):
         self.nr_steps = nr_steps
         self.nr_patches: Optional[int] = None
         self.dx = None
+
+        self.return_nan_when_prediction_changes = return_nan_when_prediction_changes
 
         # Asserts and warnings.
         if not self.disable_warnings:
@@ -305,6 +310,13 @@ class Continuity(PerturbationMetric):
             )
             x_input = model.shape_input(x_perturbed, x.shape, channel_first=True)
 
+            prediction_changed = (
+                model.predict(np.expand_dims(x, 0)).argmax(axis=-1)[0]
+                != model.predict(x_input).argmax(axis=-1)[0]
+                if self.return_nan_when_prediction_changes
+                else False
+            )
+
             # Generate explanations on perturbed input.
             a_perturbed = self.explain_func(
                 model=model.get_model(),
@@ -339,6 +351,10 @@ class Continuity(PerturbationMetric):
             for ix_patch, top_left_coords in enumerate(
                 itertools.product(*axis_iterators)
             ):
+                if prediction_changed:
+                    results[ix_patch].append(np.nan)
+                    continue
+
                 # Create slice for patch.
                 patch_slice = utils.create_patch_slice(
                     patch_size=self.patch_size,

--- a/quantus/metrics/robustness/continuity.py
+++ b/quantus/metrics/robustness/continuity.py
@@ -7,7 +7,7 @@
 # Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
 
 import itertools
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional
 import numpy as np
 
 from quantus.helpers import asserts

--- a/quantus/metrics/robustness/local_lipschitz_estimate.py
+++ b/quantus/metrics/robustness/local_lipschitz_estimate.py
@@ -55,6 +55,7 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
         default_plot_func: Optional[Callable] = None,
         disable_warnings: bool = False,
         display_progressbar: bool = False,
+        return_nan_when_prediction_changes: bool = False,
         **kwargs,
     ):
         """
@@ -99,6 +100,8 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
             Indicates whether the warnings are printed, default=False.
         display_progressbar: boolean
             Indicates whether a tqdm-progress-bar is printed, default=False.
+        return_nan_when_prediction_changes: boolean
+            When set to true, metric will be evaluated to NaN in case prediction changes after perturbation applied.
         kwargs: optional
             Keyword arguments.
         """
@@ -142,6 +145,8 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
         if norm_denominator is None:
             norm_denominator = distance_euclidean
         self.norm_denominator = norm_denominator
+
+        self.return_nan_when_prediction_changes = return_nan_when_prediction_changes
 
         # Asserts and warnings.
         if not self.disable_warnings:
@@ -315,6 +320,15 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
                 **self.perturb_func_kwargs,
             )
 
+            changed_prediction_indexes = (
+                np.argwhere(
+                    model.predict(x_batch).argmax(axis=-1)
+                    != model.predict(x_perturbed).argmax(axis=-1)
+                ).reshape(-1)
+                if self.return_nan_when_prediction_changes
+                else []
+            )
+
             x_input = model.shape_input(
                 x=x_perturbed,
                 shape=x_batch.shape,
@@ -347,6 +361,13 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
 
             # Measure similarity for each instance separately.
             for instance_id in range(batch_size):
+                if (
+                    self.return_nan_when_prediction_changes
+                    and instance_id in changed_prediction_indexes
+                ):
+                    similarities[instance_id, step_id] = np.nan
+                    continue
+
                 similarity = self.similarity_func(
                     a=a_batch[instance_id].flatten(),
                     b=a_perturbed[instance_id].flatten(),
@@ -356,8 +377,8 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
                     norm_denominator=self.norm_denominator,
                 )
                 similarities[instance_id, step_id] = similarity
-
-        return np.nanmax(similarities, axis=1)
+        max_func = np.max if self.return_nan_when_prediction_changes else np.nanmax
+        return max_func(similarities, axis=1)
 
     def custom_preprocess(
         self,

--- a/quantus/metrics/robustness/max_sensitivity.py
+++ b/quantus/metrics/robustness/max_sensitivity.py
@@ -6,7 +6,7 @@
 # You should have received a copy of the GNU Lesser General Public License along with Quantus. If not, see <https://www.gnu.org/licenses/>.
 # Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional
 import numpy as np
 
 from quantus.helpers import asserts

--- a/tests/metrics/test_robustness_metrics.py
+++ b/tests/metrics/test_robustness_metrics.py
@@ -720,7 +720,7 @@ def test_continuity(
                     "upper_bound": 255.0,
                     "nr_samples": 10,
                     "disable_warnings": True,
-                    "validate_predictions_not_changed": True,
+                    "return_nan_when_prediction_changes": True,
                 },
                 "call": {
                     "explain_func": explain,

--- a/tests/metrics/test_robustness_metrics.py
+++ b/tests/metrics/test_robustness_metrics.py
@@ -1,7 +1,9 @@
 from typing import Union
 
+import numpy as np
 import pytest
 from pytest_lazyfixture import lazy_fixture
+from typing import Callable
 
 from quantus.functions.explanation_func import explain
 from quantus.functions.discretise_func import floating_points, rank, sign, top_n_sign
@@ -31,7 +33,9 @@ from tests.fixtures import *
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -48,7 +52,9 @@ from tests.fixtures import *
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -64,7 +70,9 @@ from tests.fixtures import *
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -81,7 +89,9 @@ from tests.fixtures import *
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -97,7 +107,9 @@ from tests.fixtures import *
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -114,7 +126,9 @@ from tests.fixtures import *
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -133,7 +147,30 @@ from tests.fixtures import *
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Gradient",},
+                    "explain_func_kwargs": {
+                        "method": "Gradient",
+                    },
+                },
+            },
+            {"min": 0.0, "max": 1.0},
+        ),
+        (
+            lazy_fixture("load_mnist_model_tf"),
+            lazy_fixture("load_mnist_images_tf"),
+            {
+                "init": {
+                    "lower_bound": 0.2,
+                    "nr_samples": 10,
+                    "disable_warnings": True,
+                    "display_progressbar": True,
+                    "abs": True,
+                    "normalise": True,
+                },
+                "call": {
+                    "explain_func": explain,
+                    "explain_func_kwargs": {
+                        "method": "Gradient",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -158,14 +195,21 @@ def test_max_sensitivity(
         explain = call_params["explain_func"]
         explain_func_kwargs = call_params.get("explain_func_kwargs", {})
         a_batch = explain(
-            model=model, inputs=x_batch, targets=y_batch, **explain_func_kwargs,
+            model=model,
+            inputs=x_batch,
+            targets=y_batch,
+            **explain_func_kwargs,
         )
     elif "a_batch" in data:
         a_batch = data["a_batch"]
     else:
         a_batch = None
     scores = MaxSensitivity(**init_params)(
-        model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch, **call_params,
+        model=model,
+        x_batch=x_batch,
+        y_batch=y_batch,
+        a_batch=a_batch,
+        **call_params,
     )
 
     if isinstance(expected, float):
@@ -192,7 +236,9 @@ def test_max_sensitivity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -210,7 +256,9 @@ def test_max_sensitivity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -227,7 +275,9 @@ def test_max_sensitivity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -245,7 +295,9 @@ def test_max_sensitivity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -262,7 +314,9 @@ def test_max_sensitivity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -280,7 +334,9 @@ def test_max_sensitivity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -305,14 +361,21 @@ def test_local_lipschitz_estimate(
         explain = call_params["explain_func"]
         explain_func_kwargs = call_params.get("explain_func_kwargs", {})
         a_batch = explain(
-            model=model, inputs=x_batch, targets=y_batch, **explain_func_kwargs,
+            model=model,
+            inputs=x_batch,
+            targets=y_batch,
+            **explain_func_kwargs,
         )
     elif "a_batch" in data:
         a_batch = data["a_batch"]
     else:
         a_batch = None
     scores = LocalLipschitzEstimate(**init_params)(
-        model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch, **call_params,
+        model=model,
+        x_batch=x_batch,
+        y_batch=y_batch,
+        a_batch=a_batch,
+        **call_params,
     )
     assert scores is not None, "Test failed."
 
@@ -334,7 +397,9 @@ def test_local_lipschitz_estimate(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"exception": ValueError},
@@ -352,7 +417,9 @@ def test_local_lipschitz_estimate(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -370,7 +437,9 @@ def test_local_lipschitz_estimate(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"exception": ValueError},
@@ -388,7 +457,9 @@ def test_local_lipschitz_estimate(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -406,7 +477,9 @@ def test_local_lipschitz_estimate(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"exception": ValueError},
@@ -424,7 +497,9 @@ def test_local_lipschitz_estimate(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -449,7 +524,10 @@ def test_continuity(
         explain = call_params["explain_func"]
         explain_func_kwargs = call_params.get("explain_func_kwargs", {})
         a_batch = explain(
-            model=model, inputs=x_batch, targets=y_batch, **explain_func_kwargs,
+            model=model,
+            inputs=x_batch,
+            targets=y_batch,
+            **explain_func_kwargs,
         )
     elif "a_batch" in data:
         a_batch = data["a_batch"]
@@ -468,7 +546,11 @@ def test_continuity(
         return
 
     scores = Continuity(**init_params)(
-        model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch, **call_params,
+        model=model,
+        x_batch=x_batch,
+        y_batch=y_batch,
+        a_batch=a_batch,
+        **call_params,
     )
     assert scores is not None, "Test failed."
 
@@ -489,7 +571,9 @@ def test_continuity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -507,7 +591,9 @@ def test_continuity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -524,7 +610,9 @@ def test_continuity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -542,7 +630,9 @@ def test_continuity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -559,7 +649,9 @@ def test_continuity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
@@ -577,10 +669,33 @@ def test_continuity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
             },
             {"min": 0.0, "max": 1.0},
+        ),
+        (
+            lazy_fixture("load_mnist_model"),
+            lazy_fixture("load_mnist_images"),
+            {
+                "a_batch_generate": False,
+                "init": {
+                    "lower_bound": 1.0,
+                    "upper_bound": 255.0,
+                    "nr_samples": 10,
+                    "disable_warnings": True,
+                    "validate_predictions_not_changed": True,
+                },
+                "call": {
+                    "explain_func": explain,
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
+                },
+            },
+            np.nan,
         ),
     ],
 )
@@ -602,16 +717,25 @@ def test_avg_sensitivity(
         explain = call_params["explain_func"]
         explain_func_kwargs = call_params.get("explain_func_kwargs", {})
         a_batch = explain(
-            model=model, inputs=x_batch, targets=y_batch, **explain_func_kwargs,
+            model=model,
+            inputs=x_batch,
+            targets=y_batch,
+            **explain_func_kwargs,
         )
     elif "a_batch" in data:
         a_batch = data["a_batch"]
     else:
         a_batch = None
     scores = AvgSensitivity(**init_params)(
-        model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch, **call_params,
+        model=model,
+        x_batch=x_batch,
+        y_batch=y_batch,
+        a_batch=a_batch,
+        **call_params,
     )
-    if isinstance(expected, float):
+    if np.isnan(expected):
+        assert np.isnan(scores).all(), "Test failed."
+    elif isinstance(expected, float):
         assert all(s == expected for s in scores), "Test failed."
     else:
         assert np.all(
@@ -634,7 +758,9 @@ def test_avg_sensitivity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
                 "a_batch_generate": False,
             },
@@ -651,7 +777,9 @@ def test_avg_sensitivity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
                 "a_batch_generate": False,
             },
@@ -668,7 +796,9 @@ def test_avg_sensitivity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
                 "a_batch_generate": False,
             },
@@ -685,7 +815,9 @@ def test_avg_sensitivity(
                 },
                 "call": {
                     "explain_func": explain,
-                    "explain_func_kwargs": {"method": "Saliency",},
+                    "explain_func_kwargs": {
+                        "method": "Saliency",
+                    },
                 },
                 "a_batch_generate": False,
             },
@@ -709,7 +841,12 @@ def test_consistency(
 
     if params.get("a_batch_generate", True):
         explain = params["explain_func"]
-        a_batch = explain(model=model, inputs=x_batch, targets=y_batch, **call_params,)
+        a_batch = explain(
+            model=model,
+            inputs=x_batch,
+            targets=y_batch,
+            **call_params,
+        )
     elif "a_batch" in data:
         a_batch = data["a_batch"]
     else:
@@ -727,6 +864,10 @@ def test_consistency(
         return
 
     scores = Consistency(**init_params)(
-        model=model, x_batch=x_batch, y_batch=y_batch, a_batch=a_batch, **call_params,
+        model=model,
+        x_batch=x_batch,
+        y_batch=y_batch,
+        a_batch=a_batch,
+        **call_params,
     )[0]
     assert (scores >= expected["min"]) & (scores <= expected["max"]), "Test failed."

--- a/tests/metrics/test_robustness_metrics.py
+++ b/tests/metrics/test_robustness_metrics.py
@@ -1,8 +1,4 @@
 from typing import Union, Dict
-
-import numpy as np
-import pytest
-
 from pytest_lazyfixture import lazy_fixture
 
 from quantus.functions.explanation_func import explain
@@ -128,27 +124,6 @@ from tests.fixtures import *
                     "explain_func": explain,
                     "explain_func_kwargs": {
                         "method": "Saliency",
-                    },
-                },
-            },
-            {"min": 0.0, "max": 1.0},
-        ),
-        (
-            lazy_fixture("load_mnist_model_tf"),
-            lazy_fixture("load_mnist_images_tf"),
-            {
-                "init": {
-                    "lower_bound": 0.2,
-                    "nr_samples": 10,
-                    "disable_warnings": True,
-                    "display_progressbar": True,
-                    "abs": True,
-                    "normalise": True,
-                },
-                "call": {
-                    "explain_func": explain,
-                    "explain_func_kwargs": {
-                        "method": "Gradient",
                     },
                 },
             },

--- a/tutorials/Tutorial_Handle_Changes_In_Predictions.ipynb
+++ b/tutorials/Tutorial_Handle_Changes_In_Predictions.ipynb
@@ -42,7 +42,7 @@
    "source": [
     "#### 1) Preliminaries\n",
     "\n",
-    "1.1: Load ImageNet subset."
+    "1.1 Load ImageNet subset."
    ],
    "metadata": {
     "collapsed": false

--- a/tutorials/Tutorial_Handle_Changes_In_Predictions.ipynb
+++ b/tutorials/Tutorial_Handle_Changes_In_Predictions.ipynb
@@ -1,0 +1,331 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Handle changes in prediction during robustness evaluation.\n",
+    "Typically, during robustness evaluation, we want model prediction to stay the same. This behaviour is, however, very sensitive to perturbation function and its hyperparameter choices.\n",
+    "In this notebook we demonstrate how this could be handled in `quantus` using a simple motivating example with Average Sensitivity Metric."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[PhysicalDevice(name='/physical_device:CPU:0', device_type='CPU'),\n PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]"
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Import dependencies.\n",
+    "import pandas as pd\n",
+    "import tensorflow as tf\n",
+    "import tensorflow_datasets as tfds\n",
+    "import quantus\n",
+    "\n",
+    "tf.config.list_physical_devices()"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### 1) Preliminaries\n",
+    "\n",
+    "1.1: Load ImageNet subset."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "(32, 224, 224, 3)"
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "IMG_SIZE = 224\n",
+    "\n",
+    "ds = tfds.load(\n",
+    "    \"imagenet_v2\",\n",
+    "    split=[\"test\"],\n",
+    "    as_supervised=True,\n",
+    "    try_gcs=True,\n",
+    "    batch_size=32,\n",
+    "    data_dir=\"/tmp/tensorflow_datasets/\",\n",
+    ")\n",
+    "\n",
+    "x_batch, y_batch = ds[0].take(1).as_numpy_iterator().next()\n",
+    "x_batch = tf.image.resize(x_batch, (IMG_SIZE, IMG_SIZE)).numpy()\n",
+    "x_batch.shape"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "1.2. Load pre-trained model."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<KerasTensor: shape=(None, 224, 224, 3) dtype=float32 (created by layer 'input_2')>"
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model = tf.keras.applications.MobileNetV2()\n",
+    "model.input"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "1.3. Generate batch of predictions and explanations using baseline method \"IntegratedGradients\"."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 [==============================] - 3s 3s/step\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "(32, 224, 224)"
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y_predicted = model.predict(x_batch).argmax(axis=1)\n",
+    "a_batch_intgrad = quantus.explain(\n",
+    "    model, x_batch, y_predicted, method=\"IntegratedGradients\"\n",
+    ")\n",
+    "a_batch_intgrad.shape"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### 2) Quantitative evaluation with Quantus\n",
+    "\n",
+    "All robustness metrics accept constructor keyword argument `return_nan_when_prediction_changes`, as the name suggests,\n",
+    "when set to `True`, the metric will be evaluated to `nan` when predictions change."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "  0%|          | 0/1 [00:00<?, ?it/s]",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "09d156df79e8436f88cd6bbc3ea05f3e"
+      },
+      "application/json": {
+       "n": 0,
+       "total": 1,
+       "elapsed": 0.023797988891601562,
+       "ncols": null,
+       "nrows": null,
+       "prefix": "",
+       "ascii": false,
+       "unit": "it",
+       "unit_scale": false,
+       "rate": null,
+       "bar_format": null,
+       "postfix": null,
+       "unit_divisor": 1000,
+       "initial": 0,
+       "colour": null
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/artemsereda/Documents/PycharmProjects/Quantus/quantus/helpers/warn.py:262: UserWarning: The settings for perturbing input e.g., 'perturb_func' didn't cause change in input. Reconsider the parameter settings.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "  0%|          | 0/1 [00:00<?, ?it/s]",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "0da17c01fa764678b206598b3e95728d"
+      },
+      "application/json": {
+       "n": 0,
+       "total": 1,
+       "elapsed": 0.045575857162475586,
+       "ncols": null,
+       "nrows": null,
+       "prefix": "",
+       "ascii": false,
+       "unit": "it",
+       "unit_scale": false,
+       "rate": null,
+       "bar_format": null,
+       "postfix": null,
+       "unit_divisor": 1000,
+       "initial": 0,
+       "colour": null
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "results = quantus.evaluate(\n",
+    "    metrics={\n",
+    "        \"DefaultAvgSensitivity\": quantus.AvgSensitivity(\n",
+    "            nr_samples=20, disable_warnings=True, display_progressbar=True\n",
+    "        ),\n",
+    "        \"AvgSensitivityWithNan\": quantus.AvgSensitivity(\n",
+    "            nr_samples=20,\n",
+    "            disable_warnings=True,\n",
+    "            return_nan_when_prediction_changes=True,\n",
+    "            display_progressbar=True\n",
+    "        ),\n",
+    "    },\n",
+    "    xai_methods={\"IntegratedGradients\": a_batch_intgrad},\n",
+    "    model=model,\n",
+    "    x_batch=x_batch,\n",
+    "    y_batch=y_batch,\n",
+    "    explain_func=quantus.explain,\n",
+    "    explain_func_kwargs={\"method\": \"IntegratedGradients\"},\n",
+    "    softmax=True,\n",
+    "    channel_first=True,\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Display results in tabular form."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "                                  0         1         2         3         4   \\\nNo Prediction Change Check  0.003274  0.003258  0.008044  0.005117  0.007698   \nNan On Prediction Change         NaN       NaN  0.008044  0.005117  0.007699   \n\n                                  5         6        7         8         9   \\\nNo Prediction Change Check  0.004486  0.003926  0.00226  0.004641  0.009831   \nNan On Prediction Change    0.004486       NaN      NaN       NaN  0.009832   \n\n                            ...        22      23        24        25  \\\nNo Prediction Change Check  ...  0.005673  0.0055  0.004242  0.007323   \nNan On Prediction Change    ...  0.005673  0.0055       NaN  0.007323   \n\n                                  26        27        28        29        30  \\\nNo Prediction Change Check  0.005993  0.007763  0.009405  0.012347  0.004398   \nNan On Prediction Change    0.005996  0.007763  0.009405  0.012347       NaN   \n\n                                  31  \nNo Prediction Change Check  0.011894  \nNan On Prediction Change         NaN  \n\n[2 rows x 32 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>0</th>\n      <th>1</th>\n      <th>2</th>\n      <th>3</th>\n      <th>4</th>\n      <th>5</th>\n      <th>6</th>\n      <th>7</th>\n      <th>8</th>\n      <th>9</th>\n      <th>...</th>\n      <th>22</th>\n      <th>23</th>\n      <th>24</th>\n      <th>25</th>\n      <th>26</th>\n      <th>27</th>\n      <th>28</th>\n      <th>29</th>\n      <th>30</th>\n      <th>31</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>No Prediction Change Check</th>\n      <td>0.003274</td>\n      <td>0.003258</td>\n      <td>0.008044</td>\n      <td>0.005117</td>\n      <td>0.007698</td>\n      <td>0.004486</td>\n      <td>0.003926</td>\n      <td>0.00226</td>\n      <td>0.004641</td>\n      <td>0.009831</td>\n      <td>...</td>\n      <td>0.005673</td>\n      <td>0.0055</td>\n      <td>0.004242</td>\n      <td>0.007323</td>\n      <td>0.005993</td>\n      <td>0.007763</td>\n      <td>0.009405</td>\n      <td>0.012347</td>\n      <td>0.004398</td>\n      <td>0.011894</td>\n    </tr>\n    <tr>\n      <th>Nan On Prediction Change</th>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>0.008044</td>\n      <td>0.005117</td>\n      <td>0.007699</td>\n      <td>0.004486</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>0.009832</td>\n      <td>...</td>\n      <td>0.005673</td>\n      <td>0.0055</td>\n      <td>NaN</td>\n      <td>0.007323</td>\n      <td>0.005996</td>\n      <td>0.007763</td>\n      <td>0.009405</td>\n      <td>0.012347</td>\n      <td>NaN</td>\n      <td>NaN</td>\n    </tr>\n  </tbody>\n</table>\n<p>2 rows × 32 columns</p>\n</div>"
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.DataFrame(\n",
+    "    [\n",
+    "        results[\"IntegratedGradients\"][\"DefaultAvgSensitivity\"],\n",
+    "        results[\"IntegratedGradients\"][\"AvgSensitivityWithNan\"],\n",
+    "    ],\n",
+    "    index=[\"No Prediction Change Check\", \"Nan On Prediction Change\"],\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
### Description
Typically, when evaluating robustness, we want predictions not to change after the perturbation function is applied to `x_batch`. Add flag to return nan's for images, whose predictions did change.


### Implemented changes
  - [ ] Added flag `return_nan_when_prediction_changes` to robustness metrics inheriting from `PerturbationMetric`
  - [ ] Added test case to check nan's are returned
  - [ ] Added notebook showcasing this behavior.

### Minimum acceptance criteria
- No breaking change introduced.
