### PR TITLE
bug: default value of explain_func_kwargs cannot be unpacked.

### DIFF
--- a/quantus/evaluation.py
+++ b/quantus/evaluation.py
@@ -25,7 +25,7 @@ def evaluate(
     s_batch: Union[np.ndarray, None] = None,
     agg_func: Callable = lambda x: x,
     progress: bool = False,
-    explain_func_kwargs: Optional[dict] = {},
+    explain_func_kwargs: Optional[dict] = None,
     **call_kwargs,
 ) -> Optional[dict]:
     """
@@ -74,6 +74,8 @@ def evaluate(
             "Define the Quantus evaluation metrics that you want to evaluate the explanations against."
         )
         return None
+    if explain_func_kwargs is None:
+        explain_func_kwargs = dict()
 
     results: Dict[str, dict] = {}
 

--- a/quantus/evaluation.py
+++ b/quantus/evaluation.py
@@ -75,7 +75,7 @@ def evaluate(
         )
         return None
     if explain_func_kwargs is None:
-        explain_func_kwargs = dict()
+        explain_func_kwargs = {}
 
     results: Dict[str, dict] = {}
 

--- a/quantus/evaluation.py
+++ b/quantus/evaluation.py
@@ -25,7 +25,7 @@ def evaluate(
     s_batch: Union[np.ndarray, None] = None,
     agg_func: Callable = lambda x: x,
     progress: bool = False,
-    explain_func_kwargs: Optional[dict] = None,
+    explain_func_kwargs: Optional[dict] = {},
     **call_kwargs,
 ) -> Optional[dict]:
     """


### PR DESCRIPTION
### Description
version: 0.3.0
`quantus.evaluate` now throws the following error for default value of `explain_func_kwargs = None`:
```
TypeError: 'NoneType' object is not a mapping
```

The error happens when `explain_func_kwargs` is unpacked at [L:105](https://github.com/understandable-machine-intelligence-lab/Quantus/blob/ec43ca80d83244c8e55f4600135b0d9c931f8447/quantus/evaluation.py#L105)

A quick fix is setting `explain_func_kwargs = dict()` if its None.

@annahedstroem
