### PR TITLE
improve error message

### DIFF
--- a/quantus/helpers/utils.py
+++ b/quantus/helpers/utils.py
@@ -253,7 +253,7 @@ def infer_channel_first(x: np.array) -> bool:
         False if input shape is (nr_batch, img_width, img_height, nr_channels).
         An error is raised if the three last dimensions are equal.
     """
-    err_msg = "Ambiguous input shape. Cannot infer channel-first/channel-last order."
+    err_msg = "Ambiguous input shape. Cannot infer channel-first/channel-last order. Try setting the `channel_first` argument"
 
     if len(np.shape(x)) == 2:
         return True


### PR DESCRIPTION
Added a small suggestion in error message thrown by for example `quantus.evaluate` if it cannot determine channel-order. Using metrics directly, its easier to observe that such a parameter exists, such as [here](https://github.com/understandable-machine-intelligence-lab/Quantus/blob/ec43ca80d83244c8e55f4600135b0d9c931f8447/quantus/metrics/localisation/pointing_game.py#L118)

