### PR TITLE
Added AUC calculation to Pixel-Flipping

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest mypy
+        python -m pip install flake8 pytest mypy==0.982
         python -m pip install --upgrade typing-extensions
         python -m pip install black
         if [ -f requirements_test.txt ]; then pip install -r requirements_test.txt; fi

--- a/quantus/helpers/utils.py
+++ b/quantus/helpers/utils.py
@@ -962,10 +962,13 @@ def offset_coordinates(
     """
     x = indices // img_shape[2]
     y = indices % img_shape[2]
+
     x += offset[0]
     y += offset[1]
+
     valid = ~((x < 0) | (y < 0) | (x >= img_shape[1]) | (y >= img_shape[2]))
     off_coords = indices + offset[0] * img_shape[2] + offset[1]
+
     return off_coords[valid], valid
 
 

--- a/quantus/metrics/faithfulness/pixel_flipping.py
+++ b/quantus/metrics/faithfulness/pixel_flipping.py
@@ -47,6 +47,7 @@ class PixelFlipping(PerturbationMetric):
         perturb_func_kwargs: Optional[Dict[str, Any]] = None,
         return_aggregate: bool = False,
         aggregate_func: Callable = np.mean,
+        return_auc_per_sample: bool = False,
         default_plot_func: Optional[Callable] = None,
         disable_warnings: bool = False,
         display_progressbar: bool = False,
@@ -78,6 +79,8 @@ class PixelFlipping(PerturbationMetric):
             Indicates if an aggregated score should be computed over all instances.
         aggregate_func: callable
             Callable that aggregates the scores given an evaluation call.
+        return_auc_per_sample: boolean
+            Indicates if an AUC score should be computed over the curve and returned.
         default_plot_func: callable
             Callable that plots the metrics result.
         disable_warnings: boolean
@@ -118,6 +121,7 @@ class PixelFlipping(PerturbationMetric):
 
         # Save metric-specific attributes.
         self.features_in_step = features_in_step
+        self.return_auc_per_sample = return_auc_per_sample
 
         # Asserts and warnings.
         if not self.disable_warnings:
@@ -263,7 +267,7 @@ class PixelFlipping(PerturbationMetric):
 
         Returns
         -------
-           : list
+        list
             The evaluation results.
         """
 
@@ -296,6 +300,9 @@ class PixelFlipping(PerturbationMetric):
             x_input = model.shape_input(x_perturbed, x.shape, channel_first=True)
             y_pred_perturb = float(model.predict(x_input)[:, y])
             preds[i_ix] = y_pred_perturb
+
+        if self.return_auc_per_sample:
+            return utils.calculate_auc(preds)
 
         return preds
 


### PR DESCRIPTION
### Description
- Enable the user to return an AUC score instead of a PixelFlipping curve

### Implemented changes
- Changes in `pixel_flipping.py` script

### Minimum acceptance criteria
- All tests pass
