### PR TITLE
Fix IROF metric - perturbation accumulation and counting the segments

### DIFF
--- a/quantus/metrics/faithfulness/irof.py
+++ b/quantus/metrics/faithfulness/irof.py
@@ -295,6 +295,7 @@ class IROF(PerturbationMetric):
         s_indices = np.argsort(-att_segs)
 
         preds = []
+        x_prev_perturbed = x
 
         for i_ix, s_ix in enumerate(s_indices):
 
@@ -302,12 +303,12 @@ class IROF(PerturbationMetric):
             a_ix = np.nonzero((segments == s_ix).flatten())[0]
 
             x_perturbed = self.perturb_func(
-                arr=x,
+                arr=x_prev_perturbed,
                 indices=a_ix,
                 indexed_axes=self.a_axes,
                 **self.perturb_func_kwargs,
             )
-            warn.warn_perturbation_caused_no_change(x=x, x_perturbed=x_perturbed)
+            warn.warn_perturbation_caused_no_change(x=x_prev_perturbed, x_perturbed=x_perturbed)
 
             # Predict on perturbed input x.
             x_input = model.shape_input(x_perturbed, x.shape, channel_first=True)
@@ -315,6 +316,7 @@ class IROF(PerturbationMetric):
 
             # Normalise the scores to be within range [0, 1].
             preds.append(float(y_pred_perturb / y_pred))
+            x_prev_perturbed = x_perturbed
 
         # Calculate the area over the curve (AOC) score.
         aoc = len(preds) - utils.calculate_auc(np.array(preds))

--- a/quantus/metrics/faithfulness/irof.py
+++ b/quantus/metrics/faithfulness/irof.py
@@ -283,7 +283,7 @@ class IROF(PerturbationMetric):
             img=np.moveaxis(x, 0, -1).astype("double"),
             segmentation_method=self.segmentation_method,
         )
-        nr_segments = segments.max()
+        nr_segments = len(np.unique(segments))
         asserts.assert_nr_segments(nr_segments=nr_segments)
 
         # Calculate average attribution of each segment.


### PR DESCRIPTION
### Description
- During IROF computation, perturbation of subsequent segments should be accumulated. Until now, segments were perturbated one by one. Hence, incorrect AOC values were returned. 
- Default segmentation function "slic" assign numbers for superpixel starting from 0, which makes existing `len(np.unique(segments))` miss one segment.

### Implemented changes
- [x] Accumulate segments perturbation during IROF computation.
- [x] Fix counting the image segments.
