### PR TITLE
Fix minor misleading error message in Robustness metrics

### DIFF
--- a/quantus/helpers/asserts.py
+++ b/quantus/helpers/asserts.py
@@ -294,8 +294,8 @@ def assert_explain_func(explain_func: Callable) -> None:
     None
     """
     assert callable(explain_func), (
-        "Make sure 'explain_func' is a Callable that takes model, x_batch, "
-        "y_batch and **kwargs as arguments."
+        "Make sure 'explain_func' is a Callable that takes model, inputs, "
+        "targets and **kwargs as arguments."
     )
 
 


### PR DESCRIPTION
### Description
- When failing to provide an explain_func for the robustness metrics, an error message states:
`AssertionError:` Make sure 'explain_func' is a Callable that takes model, x_batch, y_batch and **kwargs as arguments.`

However, the correct signature for explain_func is `model, inputs, targets and **kwargs`.
- This PR fixes the issue
- Address the issue #201.
- 
### Implemented changes
  - [ ] Fix the comment.
