### PR TITLE
Fix warn_perturbation_caused_no_change

### DIFF
--- a/quantus/helpers/warn.py
+++ b/quantus/helpers/warn.py
@@ -246,7 +246,7 @@ def deprecation_warnings(kwargs: dict) -> None:
 
 def warn_perturbation_caused_no_change(x: np.ndarray, x_perturbed: np.ndarray) -> None:
     """
-    Warn that perturbation applied to input caused change so that input and perturbed input is not the same.
+    Warn that perturbation applied to input caused no change so that input and perturbed input is the same.
 
     Parameters
     ----------
@@ -259,7 +259,7 @@ def warn_perturbation_caused_no_change(x: np.ndarray, x_perturbed: np.ndarray) -
     -------
     None
     """
-    if (x.flatten() != x_perturbed.flatten()).any():
+    if np.allclose(x, x_perturbed, equal_nan=True):
         warnings.warn(
             "The settings for perturbing input e.g., 'perturb_func' "
             "didn't cause change in input. "


### PR DESCRIPTION
### Description
The previous implementation of `warn_perturbation_caused_no_change` raises a warning if **any** element of the perturbed input **differs** from the original input. This behaviour contradicts the function name. Additionally, comparing floats with the `==` operator can be problematic (false negatives) due to error accumulation during float operations.

After this fix, warnings about no change in perturbation won't be raised if there has actually been a change in input. Moreover, the condition for raising the warning handles floats well by using `np.allclose`.

### Implemented changes
- [x] Fix condition when warining is raised.
- [x] Fix docstring.
