### PR TITLE
setuptools-bug fixed, extra_requires not correctly identified

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools<=58.0.0
 cachetools>=5.3.0
 matplotlib>=3.3.4
 numpy>=1.19.5


### PR DESCRIPTION
### Description
- Fixing external bug as identified in: https://github.com/understandable-machine-intelligence-lab/Quantus/actions/runs/4883757121/jobs/8715544577

```bash
error in quantus setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.
```
### Implemented changes
- Addition to `requirements.txt`