### PR TITLE
Add py.typed

### DIFF
--- a/quantus/py.typed
+++ b/quantus/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The mypy package uses inline types.


### PR DESCRIPTION
### Description
- Quantus uses inline type-hints, `py.typed` is a marker specifying, that package is typed. 
- More about it here [EP 484](https://peps.python.org/pep-0484). 
- In nutshell, adding this will make mypy scan type hints exported by Quantus.

### Implemented changes
  - [x] add `py.typed`

### Minimum acceptance criteria
No breaking changes expected. 