### PR TITLE
Create transparency with respect to the metric’s data and model applicability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Tests are written using [pytest](https://github.com/pytest-dev/pytest) and execu
 with [codecov](https://github.com/codecov/codecov-action) for coverage reports.
 We use [tox](https://tox.wiki/en/latest/) for test automation. For complete list of CLI commands, please refer
 to [tox - CLI interface](https://tox.wiki/en/latest/cli_interface.html).
-To perform the tests for all supported python versions execute the following CLI command (a re-intall of tox is necessary):
+To perform the tests for all supported python versions execute the following CLI command (a re-install of tox is necessary):
 
 ```shell
 python3 -m pip install tox

--- a/docs/source/getting_started/getting_started_example.md
+++ b/docs/source/getting_started/getting_started_example.md
@@ -319,7 +319,7 @@ quantus.AVAILABLE_PERTURBATION_FUNCTIONS
 quantus.AVAILABLE_NORMALISATION_FUNCTIONS
 
 # To get the scores of the last evaluated batch.
-metric_instance_called.last_results
+metric_instance_called.evaluation_scores
 ````
 
 Per default, 

--- a/quantus/functions/loss_func.py
+++ b/quantus/functions/loss_func.py
@@ -34,7 +34,7 @@ def mse(a: np.array, b: np.array, **kwargs) -> float:
 
     if normalise:
         # Calculate MSE in its polynomial expansion (a-b)^2 = a^2 - 2ab + b^2.
-        return np.average(((a**2) - (2 * (a * b)) + (b**2)), axis=0)
+        return np.average(((a ** 2) - (2 * (a * b)) + (b ** 2)), axis=0)
     # If no need to normalise, return (a-b)^2.
 
     return np.average(((a - b) ** 2), axis=0)

--- a/quantus/functions/normalise_func.py
+++ b/quantus/functions/normalise_func.py
@@ -231,13 +231,13 @@ def normalise_by_average_second_moment_estimate(
 
     # Check that square root of the second momment estimatte is nonzero.
     second_moment_sqrt = np.sqrt(
-        np.sum(a**2, axis=normalise_axes, keepdims=True)
+        np.sum(a ** 2, axis=normalise_axes, keepdims=True)
         / np.prod([a.shape[n] for n in normalise_axes])
     )
 
     if all(second_moment_sqrt != 0):
         a /= np.sqrt(
-            np.sum(a**2, axis=normalise_axes, keepdims=True)
+            np.sum(a ** 2, axis=normalise_axes, keepdims=True)
             / np.prod([a.shape[n] for n in normalise_axes])
         )
     else:

--- a/quantus/helpers/enums.py
+++ b/quantus/helpers/enums.py
@@ -8,9 +8,9 @@ class DataType(Enum):
     - TABULAR: Represents tabular data.
     - TEXT: Represents text data.
     """
-    IMAGE = "image"
-    TIMESERIES = "time-series"
-    TABULAR = "tabular"
+    IMAGE = "image" # 3D data
+    TIMESERIES = "time-series" # 1D data
+    TABULAR = "tabular" # 2D data
     TEXT = "text"
 
 

--- a/quantus/helpers/enums.py
+++ b/quantus/helpers/enums.py
@@ -42,7 +42,7 @@ class ScoreDirection(Enum):
 
 class EvaluationCategory(Enum):
     """
-    This enum represents different categories of explanation quality for machine learning models.
+    This enum represents different categories of explanation quality for XAI algorithms.
 
         - FAITHFULNESS: Indicates how well the explanation reflects the true features used by the model.
         - ROBUSTNESS: Represents the degree to which the explanation remains consistent under small perturbations in the input.

--- a/quantus/helpers/enums.py
+++ b/quantus/helpers/enums.py
@@ -1,0 +1,34 @@
+from enum import Enum
+
+
+class DataType(Enum):
+    """
+    This enum represents the different types of data that a metric implementation currently supports.
+    - IMAGE: Represents image data.
+    - TABULAR: Represents tabular data.
+    - TEXT: Represents text data.
+    """
+    IMAGE = "image"
+    TIMESERIES = "time-series"
+    TABULAR = "tabular"
+    TEXT = "text"
+
+
+class ModelType(Enum):
+    """
+    This enum represents the different types of models that a metric can work with.
+    - TORCH: Represents PyTorch models.
+    - TF: Represents TensorFlow models.
+    """
+    TORCH = "torch"
+    TF = "tensorflow"
+
+
+class ScoreDirection(Enum):
+    """
+    This enum represents the direction that the score of a metric should go in for better results.
+    - HIGHER: Higher scores are better.
+    - LOWER: Lower scores are better.
+    """
+    HIGHER = "higher"
+    LOWER = "lower"

--- a/quantus/helpers/enums.py
+++ b/quantus/helpers/enums.py
@@ -4,22 +4,26 @@ from enum import Enum
 class DataType(Enum):
     """
     This enum represents the different types of data that a metric implementation currently supports.
-    - IMAGE: Represents image data.
-    - TABULAR: Represents tabular data.
-    - TEXT: Represents text data.
+
+        - IMAGE: Represents image data.
+        - TABULAR: Represents tabular data.
+        - TEXT: Represents text data.
     """
-    IMAGE = "image" # 3D data
-    TIMESERIES = "time-series" # 1D data
-    TABULAR = "tabular" # 2D data
+
+    IMAGE = "image"  # 3D data
+    TIMESERIES = "time-series"  # 1D data
+    TABULAR = "tabular"  # 2D data
     TEXT = "text"
 
 
 class ModelType(Enum):
     """
     This enum represents the different types of models that a metric can work with.
-    - TORCH: Represents PyTorch models.
-    - TF: Represents TensorFlow models.
+
+        - TORCH: Represents PyTorch models.
+        - TF: Represents TensorFlow models.
     """
+
     TORCH = "torch"
     TF = "tensorflow"
 
@@ -27,8 +31,31 @@ class ModelType(Enum):
 class ScoreDirection(Enum):
     """
     This enum represents the direction that the score of a metric should go in for better results.
-    - HIGHER: Higher scores are better.
-    - LOWER: Lower scores are better.
+
+        - HIGHER: Higher scores are better.
+        - LOWER: Lower scores are better.
     """
+
     HIGHER = "higher"
     LOWER = "lower"
+
+
+class EvaluationCategory(Enum):
+    """
+    This enum represents different categories of explanation quality for machine learning models.
+
+        - FAITHFULNESS: Indicates how well the explanation reflects the true features used by the model.
+        - ROBUSTNESS: Represents the degree to which the explanation remains consistent under small perturbations in the input.
+        - RANDOMISATION: Measures the quality of the explanation in terms of difference in explanation when randomness is introduced.
+        - COMPLEXITY: Refers to how easy it is to understand the explanation. Lower complexity is usually better.
+        - LOCALISATION: Refers to how consistently the explanation points out the parts of the input as defined in a ground-truth segmentation mask.
+        - AXIOMATIC: Represents the quality of the explanation in terms of well-defined axioms.
+    """
+
+    FAITHFULNESS = "Faithfulness"
+    ROBUSTNESS = "Robustness"
+    RANDOMISATION = "Randomisation"
+    COMPLEXITY = "Complexity"
+    LOCALISATION = "Localisation"
+    AXIOMATIC = "Axiomatic"
+    NONE = "None"

--- a/quantus/metrics/__init__.py
+++ b/quantus/metrics/__init__.py
@@ -5,6 +5,8 @@
 # Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
 
 from quantus.metrics.base import *
+from quantus.metrics.base_batched import *
+from quantus.metrics.base_perturbed import *
 from quantus.metrics.axiomatic import *
 from quantus.metrics.complexity import *
 from quantus.metrics.faithfulness import *

--- a/quantus/metrics/axiomatic/completeness.py
+++ b/quantus/metrics/axiomatic/completeness.py
@@ -15,7 +15,12 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base_perturbed import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class Completeness(PerturbationMetric):
@@ -175,8 +180,8 @@ class Completeness(PerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -209,7 +214,7 @@ class Completeness(PerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/axiomatic/completeness.py
+++ b/quantus/metrics/axiomatic/completeness.py
@@ -47,7 +47,7 @@ class Completeness(PerturbationMetric):
     """
 
     _name = "Completeness"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/axiomatic/completeness.py
+++ b/quantus/metrics/axiomatic/completeness.py
@@ -43,14 +43,14 @@ class Completeness(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
 
-    _name = "Completeness"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.AXIOMATIC
+    name = "Completeness"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.AXIOMATIC
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/axiomatic/completeness.py
+++ b/quantus/metrics/axiomatic/completeness.py
@@ -47,12 +47,7 @@ class Completeness(PerturbationMetric):
     """
 
     _name = "Completeness"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/axiomatic/completeness.py
+++ b/quantus/metrics/axiomatic/completeness.py
@@ -15,6 +15,7 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class Completeness(PerturbationMetric):
@@ -37,7 +38,23 @@ class Completeness(PerturbationMetric):
         features through propagating activation differences." International Conference on Machine Learning. PMLR, 2017.
         3) Conservation - Grégoire Montavon et al.: "Methods for interpreting
         and understanding deep neural networks." Digital Signal Processing 73 (2018): 1-15.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Completeness"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/axiomatic/completeness.py
+++ b/quantus/metrics/axiomatic/completeness.py
@@ -14,8 +14,8 @@ from quantus.helpers import asserts
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class Completeness(PerturbationMetric):
@@ -50,6 +50,7 @@ class Completeness(PerturbationMetric):
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.AXIOMATIC
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/axiomatic/input_invariance.py
+++ b/quantus/metrics/axiomatic/input_invariance.py
@@ -34,14 +34,14 @@ class InputInvariance(BatchedPerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
 
-    _name = "Input Invariance"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.AXIOMATIC
+    name = "Input Invariance"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.AXIOMATIC
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/axiomatic/input_invariance.py
+++ b/quantus/metrics/axiomatic/input_invariance.py
@@ -15,7 +15,7 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_shift, perturb_batch
 from quantus.metrics.base_batched import BatchedPerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class InputInvariance(BatchedPerturbationMetric):
@@ -41,6 +41,7 @@ class InputInvariance(BatchedPerturbationMetric):
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.AXIOMATIC
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/axiomatic/input_invariance.py
+++ b/quantus/metrics/axiomatic/input_invariance.py
@@ -38,12 +38,7 @@ class InputInvariance(BatchedPerturbationMetric):
     """
 
     _name = "Input Invariance"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/axiomatic/input_invariance.py
+++ b/quantus/metrics/axiomatic/input_invariance.py
@@ -15,7 +15,12 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_shift, perturb_batch
 from quantus.metrics.base_batched import BatchedPerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class InputInvariance(BatchedPerturbationMetric):
@@ -152,8 +157,8 @@ class InputInvariance(BatchedPerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -186,7 +191,7 @@ class InputInvariance(BatchedPerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/axiomatic/input_invariance.py
+++ b/quantus/metrics/axiomatic/input_invariance.py
@@ -38,7 +38,7 @@ class InputInvariance(BatchedPerturbationMetric):
     """
 
     _name = "Input Invariance"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/axiomatic/non_sensitivity.py
+++ b/quantus/metrics/axiomatic/non_sensitivity.py
@@ -15,6 +15,7 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class NonSensitivity(PerturbationMetric):
@@ -32,7 +33,22 @@ class NonSensitivity(PerturbationMetric):
         3) Grégoire Montavon et al.: "Methods for interpreting and
         understanding deep neural networks." Digital Signal Processing 73 (2018): 1-15.
 
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Non-Sensitivity"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(
@@ -302,8 +318,8 @@ class NonSensitivity(PerturbationMetric):
                 # Predict on perturbed input x.
                 x_input = model.shape_input(x_perturbed, x.shape, channel_first=True)
                 y_pred_perturbed = float(model.predict(x_input)[:, y])
-                preds.append(y_pred_perturbed)
 
+                preds.append(y_pred_perturbed)
                 vars.append(np.var(preds))
 
         non_features_vars = set(list(np.argwhere(vars).flatten() < self.eps))

--- a/quantus/metrics/axiomatic/non_sensitivity.py
+++ b/quantus/metrics/axiomatic/non_sensitivity.py
@@ -37,15 +37,15 @@ class NonSensitivity(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Non-Sensitivity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.AXIOMATIC
+    name = "Non-Sensitivity"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.AXIOMATIC
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/axiomatic/non_sensitivity.py
+++ b/quantus/metrics/axiomatic/non_sensitivity.py
@@ -15,7 +15,12 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base_perturbed import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class NonSensitivity(PerturbationMetric):
@@ -178,8 +183,8 @@ class NonSensitivity(PerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -212,7 +217,7 @@ class NonSensitivity(PerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/axiomatic/non_sensitivity.py
+++ b/quantus/metrics/axiomatic/non_sensitivity.py
@@ -41,7 +41,7 @@ class NonSensitivity(PerturbationMetric):
     """
 
     _name = "Non-Sensitivity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/axiomatic/non_sensitivity.py
+++ b/quantus/metrics/axiomatic/non_sensitivity.py
@@ -14,8 +14,8 @@ from quantus.helpers import asserts
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class NonSensitivity(PerturbationMetric):
@@ -38,12 +38,14 @@ class NonSensitivity(PerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Non-Sensitivity"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.AXIOMATIC
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/axiomatic/non_sensitivity.py
+++ b/quantus/metrics/axiomatic/non_sensitivity.py
@@ -41,12 +41,7 @@ class NonSensitivity(PerturbationMetric):
     """
 
     _name = "Non-Sensitivity"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -42,6 +42,31 @@ class Metric:
     Implementation of the base Metric class.
     """
 
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def evaluation_category(self) -> EvaluationCategory:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def score_direction(self) -> ScoreDirection:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def model_applicability(self) -> Set[ModelType]:
+        return {ModelType.TORCH, ModelType.TF}
+
+    @property
+    @abstractmethod
+    def data_applicability(self) -> Set[DataType]:
+        raise NotImplementedError
+
     @asserts.attributes_check
     def __init__(
         self,
@@ -117,31 +142,6 @@ class Metric:
 
         self.evaluation_scores: Any = []
         self.all_evaluation_scores: Any = []
-
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def evaluation_category(self) -> Set[EvaluationCategory]:
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def score_direction(self) -> Set[ScoreDirection]:
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def model_applicability(self) -> Set[ModelType]:
-        return {ModelType.TORCH, ModelType.TF}
-
-    @property
-    @abstractmethod
-    def data_applicability(self) -> Set[DataType]:
-        raise NotImplementedError
 
     def __call__(
         self,

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -18,8 +18,7 @@ from quantus.helpers import asserts
 from quantus.helpers import utils
 from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
-from quantus.functions import postprocess_func
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory, EvaluationCategory
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class Metric:
@@ -49,6 +48,8 @@ class Metric:
         normalise_func_kwargs: Optional[Dict[str, Any]],
         return_aggregate: bool,
         aggregate_func: Callable,
+        #return_skill_score: bool,
+        #skill_score_samples: int,
         default_plot_func: Optional[Callable],
         disable_warnings: bool,
         display_progressbar: bool,
@@ -797,4 +798,3 @@ class Metric:
             "default_plot_func",
         ]
         return {k: v for k, v in self.__dict__.items() if k not in attr_exclude}
-

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -125,19 +125,19 @@ class Metric:
             )
 
     @property
-    def get_name(self):
+    def name(self):
         return self._name
 
     @property
-    def get_data_applicability(self):
+    def data_applicability(self):
         return self._data_applicability
 
     @property
-    def get_model_applicability(self):
+    def model_applicability(self):
         return self._model_applicability
 
     @property
-    def get_score_direction(self):
+    def score_direction(self):
         return self._score_direction
 
     def __call__(

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -40,20 +40,7 @@ from quantus.helpers.enums import (
 class Metric:
     """
     Implementation of the base Metric class.
-
-    Attributes:
-        -  _name: The name of the metric.
-        - _data_applicability: The data types that the metric implementation currently supports.
-        - _models: The model types that this metric can work with.
-        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - evaluation_category: What property/ explanation quality that this metric measures.
     """
-
-    name = "Metric"
-    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    model_applicability = {ModelType.TORCH, ModelType.TF}
-    score_direction = ScoreDirection.HIGHER
-    evaluation_category = EvaluationCategory.NONE
 
     @asserts.attributes_check
     def __init__(
@@ -64,8 +51,6 @@ class Metric:
         normalise_func_kwargs: Optional[Dict[str, Any]],
         return_aggregate: bool,
         aggregate_func: Callable,
-        # return_skill_score: bool,
-        # skill_score_samples: int,
         default_plot_func: Optional[Callable],
         disable_warnings: bool,
         display_progressbar: bool,
@@ -145,8 +130,13 @@ class Metric:
 
     @property
     @abstractmethod
+    def score_direction(self) -> Set[ScoreDirection]:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
     def model_applicability(self) -> Set[ModelType]:
-        return {ModelType.Torch, ModelType.TensorFlow}
+        return {ModelType.TORCH, ModelType.TF}
 
     @property
     @abstractmethod

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -18,12 +18,25 @@ from quantus.helpers import asserts
 from quantus.helpers import utils
 from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
+from quantus.functions import postprocess_func
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class Metric:
     """
     Implementation of the base Metric class.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Metric"
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR, DataType.TEXT}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(
@@ -100,6 +113,26 @@ class Metric:
 
         self.last_results: Any = []
         self.all_results: Any = []
+
+        if not hasattr(self, "_name") or not hasattr(self, "_data_applicability") or not hasattr(self, "_model_applicability") or not hasattr(self, "_score_direction"):
+            raise NotImplementedError(
+                "Subclasses must define name, data_applicability, model_applicability and score_direction before instantiation")
+
+    @property
+    def get_name(self):
+        return self._name
+
+    @property
+    def get_data_applicability(self):
+        return self._data_applicability
+
+    @property
+    def get_model_applicability(self):
+        return self._model_applicability
+
+    @property
+    def get_score_direction(self):
+        return self._score_direction
 
     def __call__(
         self,
@@ -227,6 +260,7 @@ class Metric:
 
         # Call custom post-processing.
         self.custom_postprocess(**data)
+
 
         if self.return_aggregate:
             if self.aggregate_func:

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -279,8 +279,6 @@ class Metric:
         # Call custom post-processing.
         self.custom_postprocess(**data)
 
-        self.skill_scores = self.compute_skill_score(a_batch=data["a_batch"])
-
         if self.return_aggregate:
             if self.aggregate_func:
                 try:
@@ -804,3 +802,14 @@ class Metric:
             "default_plot_func",
         ]
         return {k: v for k, v in self.__dict__.items() if k not in attr_exclude}
+
+    @property
+    def last_results(self):
+        print(
+            "Warning: 'last_results' has been renamed to 'evaluation_scores'. 'last_results' is removed in current version.")
+        return self.evaluation_scores
+
+    @property
+    def all_results(self):
+        print("Warning: 'all_results' has been renamed to 'all_evaluation_scores'. 'all_results' is removed in current version.")
+        return self.all_evaluation_scores

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -798,16 +798,3 @@ class Metric:
         ]
         return {k: v for k, v in self.__dict__.items() if k not in attr_exclude}
 
-
-    def compute_skill_score(self,
-                            a_batch: np.array) -> List[float]:
-        # Calculate explanation skill score.
-        skill_scores = []
-
-        # TODO. Get baseline explanation.
-        e_worst = np.random.uniform(low=a_batch.min(), high=a_batch.max(), size=a_batch.shape)
-
-        for s in self.last_results:
-            skill_scores.append(postprocess_func.explanation_skill_score(y_score=s, y_ref=e_worst))
-
-        return skill_scores

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -132,16 +132,25 @@ class Metric:
         self.evaluation_scores: Any = []
         self.all_evaluation_scores: Any = []
 
-        if (
-            not hasattr(self, "_name")
-            or not hasattr(self, "_data_applicability")
-            or not hasattr(self, "model_applicability")
-            or not hasattr(self, "score_direction")
-            or not hasattr(self, "evaluation_category")
-        ):
-            raise NotImplementedError(
-                "Subclasses must define name, data_applicability, model_applicability and score_direction before instantiation"
-            )
+    @property
+    @abstractmethod
+    def name(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def evaluation_category(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def model_applicability(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def data_applicability(self):
+        raise NotImplementedError
 
     def __call__(
         self,

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -34,7 +34,7 @@ class Metric:
     """
 
     _name = "Metric"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -19,6 +19,7 @@ from typing import (
     Union,
     Collection,
     List,
+    Set,
 )
 import matplotlib.pyplot as plt
 import numpy as np
@@ -134,22 +135,22 @@ class Metric:
 
     @property
     @abstractmethod
-    def name(self):
+    def name(self) -> str:
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def evaluation_category(self):
+    def evaluation_category(self) -> Set[EvaluationCategory]:
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def model_applicability(self):
-        raise NotImplementedError
+    def model_applicability(self) -> Set[ModelType]:
+        return {ModelType.Torch, ModelType.TensorFlow}
 
     @property
     @abstractmethod
-    def data_applicability(self):
+    def data_applicability(self) -> Set[DataType]:
         raise NotImplementedError
 
     def __call__(
@@ -806,10 +807,13 @@ class Metric:
     @property
     def last_results(self):
         print(
-            "Warning: 'last_results' has been renamed to 'evaluation_scores'. 'last_results' is removed in current version.")
+            "Warning: 'last_results' has been renamed to 'evaluation_scores'. 'last_results' is removed in current version."
+        )
         return self.evaluation_scores
 
     @property
     def all_results(self):
-        print("Warning: 'all_results' has been renamed to 'all_evaluation_scores'. 'all_results' is removed in current version.")
+        print(
+            "Warning: 'all_results' has been renamed to 'all_evaluation_scores'. 'all_results' is removed in current version."
+        )
         return self.all_evaluation_scores

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -34,12 +34,7 @@ class Metric:
     """
 
     _name = "Metric"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -34,7 +34,12 @@ class Metric:
     """
 
     _name = "Metric"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR, DataType.TEXT}
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 
@@ -114,9 +119,15 @@ class Metric:
         self.last_results: Any = []
         self.all_results: Any = []
 
-        if not hasattr(self, "_name") or not hasattr(self, "_data_applicability") or not hasattr(self, "_model_applicability") or not hasattr(self, "_score_direction"):
+        if (
+            not hasattr(self, "_name")
+            or not hasattr(self, "_data_applicability")
+            or not hasattr(self, "_model_applicability")
+            or not hasattr(self, "_score_direction")
+        ):
             raise NotImplementedError(
-                "Subclasses must define name, data_applicability, model_applicability and score_direction before instantiation")
+                "Subclasses must define name, data_applicability, model_applicability and score_direction before instantiation"
+            )
 
     @property
     def get_name(self):
@@ -260,7 +271,6 @@ class Metric:
 
         # Call custom post-processing.
         self.custom_postprocess(**data)
-
 
         if self.return_aggregate:
             if self.aggregate_func:

--- a/quantus/metrics/base.py
+++ b/quantus/metrics/base.py
@@ -29,15 +29,15 @@ class Metric:
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Metric"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.NONE
+    name = "Metric"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.NONE
 
     @asserts.attributes_check
     def __init__(
@@ -120,33 +120,13 @@ class Metric:
         if (
             not hasattr(self, "_name")
             or not hasattr(self, "_data_applicability")
-            or not hasattr(self, "_model_applicability")
-            or not hasattr(self, "_score_direction")
-            or not hasattr(self, "_evaluation_category")
+            or not hasattr(self, "model_applicability")
+            or not hasattr(self, "score_direction")
+            or not hasattr(self, "evaluation_category")
         ):
             raise NotImplementedError(
                 "Subclasses must define name, data_applicability, model_applicability and score_direction before instantiation"
             )
-
-    @property
-    def name(self):
-        return self._name
-
-    @property
-    def data_applicability(self):
-        return self._data_applicability
-
-    @property
-    def model_applicability(self):
-        return self._model_applicability
-
-    @property
-    def score_direction(self):
-        return self._score_direction
-
-    @property
-    def evaluation_category(self):
-        return self._evaluation_category
 
     def __call__(
         self,

--- a/quantus/metrics/base_batched.py
+++ b/quantus/metrics/base_batched.py
@@ -19,7 +19,7 @@ from quantus.metrics.base import Metric
 from quantus.helpers import asserts
 from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class BatchedMetric(Metric):
@@ -31,6 +31,7 @@ class BatchedMetric(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Metric"

--- a/quantus/metrics/base_batched.py
+++ b/quantus/metrics/base_batched.py
@@ -34,12 +34,7 @@ class BatchedMetric(Metric):
     """
 
     _name = "Metric"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/base_batched.py
+++ b/quantus/metrics/base_batched.py
@@ -34,7 +34,7 @@ class BatchedMetric(Metric):
     """
 
     _name = "Metric"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/base_batched.py
+++ b/quantus/metrics/base_batched.py
@@ -30,14 +30,14 @@ class BatchedMetric(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Metric"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
+    name = "Metric"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/base_batched.py
+++ b/quantus/metrics/base_batched.py
@@ -19,7 +19,12 @@ from quantus.metrics.base import Metric
 from quantus.helpers import asserts
 from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class BatchedMetric(Metric):
@@ -127,10 +132,10 @@ class BatchedMetric(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        evaluate_instance() on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        evaluate_instance() on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
-        The content of last_results will be appended to all_results (list) at the end of
+        The content of evaluation_scores will be appended to all_evaluation_scores (list) at the end of
         the evaluation call.
 
         Parameters
@@ -167,7 +172,7 @@ class BatchedMetric(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:
@@ -225,10 +230,10 @@ class BatchedMetric(Metric):
             batch_size=batch_size,
         )
 
-        self.last_results = []
+        self.evaluation_scores = []
         for data_batch in batch_generator:
             result = self.evaluate_batch(**data_batch)
-            self.last_results.extend(result)
+            self.evaluation_scores.extend(result)
 
         # Call post-processing.
         self.custom_postprocess(**data)
@@ -236,12 +241,14 @@ class BatchedMetric(Metric):
         if self.return_aggregate:
             if self.aggregate_func:
                 try:
-                    self.last_results = [self.aggregate_func(self.last_results)]
+                    self.evaluation_scores = [
+                        self.aggregate_func(self.evaluation_scores)
+                    ]
                 except:
                     print(
                         "The aggregation of evaluation scores failed. Check that "
                         "'aggregate_func' supplied is appropriate for the data "
-                        "in 'last_results'."
+                        "in 'evaluation_scores'."
                     )
             else:
                 raise KeyError(
@@ -249,9 +256,9 @@ class BatchedMetric(Metric):
                 )
 
         # Append content of last results to all results.
-        self.all_results.append(self.last_results)
+        self.all_evaluation_scores.append(self.evaluation_scores)
 
-        return self.last_results
+        return self.evaluation_scores
 
     @abstractmethod
     def evaluate_batch(

--- a/quantus/metrics/base_batched.py
+++ b/quantus/metrics/base_batched.py
@@ -19,12 +19,29 @@ from quantus.metrics.base import Metric
 from quantus.helpers import asserts
 from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class BatchedMetric(Metric):
     """
     Implementation base BatchedMetric class.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Metric"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/base_batched.py
+++ b/quantus/metrics/base_batched.py
@@ -32,17 +32,18 @@ class BatchedMetric(Metric):
     Implementation base BatchedMetric class.
 
     Attributes:
-        -  _name: The name of the metric.
-        - _data_applicability: The data types that the metric implementation currently supports.
-        - _models: The model types that this metric can work with.
+        - name: The name of the metric.
+        - data_applicability: The data types that the metric implementation currently supports.
+        - model_applicability: The model types that this metric can work with.
         - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
         - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    name = "Metric"
+    name = "BatchedMetric"
     data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     model_applicability = {ModelType.TORCH, ModelType.TF}
     score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.NONE
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/base_perturbed.py
+++ b/quantus/metrics/base_perturbed.py
@@ -9,7 +9,17 @@ import inspect
 import re
 from abc import abstractmethod
 from collections.abc import Sequence
-from typing import Any, Callable, Dict, Sequence, Optional, Tuple, Union, Collection, List
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Sequence,
+    Optional,
+    Tuple,
+    Union,
+    Collection,
+    List,
+)
 import matplotlib.pyplot as plt
 import numpy as np
 from tqdm.auto import tqdm
@@ -20,7 +30,12 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.metrics.base import Metric
 from quantus.functions import postprocess_func
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class PerturbationMetric(Metric):

--- a/quantus/metrics/base_perturbed.py
+++ b/quantus/metrics/base_perturbed.py
@@ -43,7 +43,20 @@ class PerturbationMetric(Metric):
 
     Metric categories such as Faithfulness and Robustness share certain characteristics when it comes to perturbations.
     As follows, this metric class is created which has additional attributes for perturbations.
+
+    Attributes:
+        - name: The name of the metric.
+        - data_applicability: The data types that the metric implementation currently supports.
+        - model_applicability: The model types that this metric can work with.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
+
+    name = "PerturbationMetric"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.NONE
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/base_perturbed.py
+++ b/quantus/metrics/base_perturbed.py
@@ -1,0 +1,135 @@
+"""This module implements the base class for creating evaluation metrics."""
+# This file is part of Quantus.
+# Quantus is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+# Quantus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public License along with Quantus. If not, see <https://www.gnu.org/licenses/>.
+# Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
+
+import inspect
+import re
+from abc import abstractmethod
+from collections.abc import Sequence
+from typing import Any, Callable, Dict, Sequence, Optional, Tuple, Union, Collection, List
+import matplotlib.pyplot as plt
+import numpy as np
+from tqdm.auto import tqdm
+
+from quantus.helpers import asserts
+from quantus.helpers import utils
+from quantus.helpers import warn
+from quantus.helpers.model.model_interface import ModelInterface
+from quantus.metrics.base import Metric
+from quantus.functions import postprocess_func
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+
+
+class PerturbationMetric(Metric):
+    """
+    Implementation base PertubationMetric class.
+
+    Metric categories such as Faithfulness and Robustness share certain characteristics when it comes to perturbations.
+    As follows, this metric class is created which has additional attributes for perturbations.
+    """
+
+    @asserts.attributes_check
+    def __init__(
+        self,
+        abs: bool,
+        normalise: bool,
+        normalise_func: Callable,
+        normalise_func_kwargs: Optional[Dict[str, Any]],
+        perturb_func: Callable,
+        perturb_func_kwargs: Optional[Dict[str, Any]],
+        return_aggregate: bool,
+        aggregate_func: Callable,
+        default_plot_func: Optional[Callable],
+        disable_warnings: bool,
+        display_progressbar: bool,
+        **kwargs,
+    ):
+        """
+        Initialise the PerturbationMetric base class.
+
+        Parameters
+        ----------
+        Parameters
+        ----------
+        abs: boolean
+            Indicates whether absolute operation is applied on the attribution.
+        normalise: boolean
+            Indicates whether normalise operation is applied on the attribution.
+        normalise_func: callable
+            Attribution normalisation function applied in case normalise=True.
+        normalise_func_kwargs: dict
+            Keyword arguments to be passed to normalise_func on call.
+        perturb_func: callable
+            Input perturbation function.
+        perturb_func_kwargs: dict, optional
+            Keyword arguments to be passed to perturb_func.
+        return_aggregate: boolean
+            Indicates if an aggregated score should be computed over all instances.
+        aggregate_func: callable
+            Callable that aggregates the scores given an evaluation call.
+        default_plot_func: callable
+            Callable that plots the metrics result.
+        disable_warnings: boolean
+            Indicates whether the warnings are printed.
+        display_progressbar: boolean
+            Indicates whether a tqdm-progress-bar is printed.
+        kwargs: optional
+            Keyword arguments.
+        """
+
+        # Initialize super-class with passed parameters
+        super().__init__(
+            abs=abs,
+            normalise=normalise,
+            normalise_func=normalise_func,
+            normalise_func_kwargs=normalise_func_kwargs,
+            return_aggregate=return_aggregate,
+            aggregate_func=aggregate_func,
+            default_plot_func=default_plot_func,
+            display_progressbar=display_progressbar,
+            disable_warnings=disable_warnings,
+            **kwargs,
+        )
+
+        # Save perturbation metric attributes.
+        self.perturb_func = perturb_func
+
+        if perturb_func_kwargs is None:
+            perturb_func_kwargs = {}
+        self.perturb_func_kwargs = perturb_func_kwargs
+
+    @abstractmethod
+    def evaluate_instance(
+        self,
+        model: ModelInterface,
+        x: np.ndarray,
+        y: Optional[np.ndarray],
+        a: Optional[np.ndarray],
+        s: Optional[np.ndarray],
+    ) -> Any:
+        """
+        Evaluate instance gets model and data for a single instance as input and returns the evaluation result.
+
+        This method needs to be implemented to use __call__().
+
+        Parameters
+        ----------
+        model: ModelInterface
+            A ModelInteface that is subject to explanation.
+        x: np.ndarray
+            The input to be evaluated on an instance-basis.
+        y: np.ndarray
+            The output to be evaluated on an instance-basis.
+        a: np.ndarray
+            The explanation to be evaluated on an instance-basis.
+        s: np.ndarray
+            The segmentation to be evaluated on an instance-basis.
+
+        Returns
+        -------
+        Any
+        """
+        raise NotImplementedError()

--- a/quantus/metrics/base_perturbed.py
+++ b/quantus/metrics/base_perturbed.py
@@ -29,7 +29,6 @@ from quantus.helpers import utils
 from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.metrics.base import Metric
-from quantus.functions import postprocess_func
 from quantus.helpers.enums import (
     ModelType,
     DataType,

--- a/quantus/metrics/complexity/complexity.py
+++ b/quantus/metrics/complexity/complexity.py
@@ -39,12 +39,7 @@ class Complexity(Metric):
     """
 
     _name = "Complexity"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/complexity/complexity.py
+++ b/quantus/metrics/complexity/complexity.py
@@ -15,6 +15,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class Complexity(Metric):
@@ -30,7 +31,22 @@ class Complexity(Metric):
         1) Umang Bhatt et al.: "Evaluating and aggregating
         feature-based model explanations." IJCAI (2020): 3016-3022.
 
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Complexity"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     # TODO. Only bool for return_aggreate..
 

--- a/quantus/metrics/complexity/complexity.py
+++ b/quantus/metrics/complexity/complexity.py
@@ -39,7 +39,7 @@ class Complexity(Metric):
     """
 
     _name = "Complexity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/complexity/complexity.py
+++ b/quantus/metrics/complexity/complexity.py
@@ -35,15 +35,15 @@ class Complexity(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Complexity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.COMPLEXITY
+    name = "Complexity"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.COMPLEXITY
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/complexity/complexity.py
+++ b/quantus/metrics/complexity/complexity.py
@@ -43,7 +43,6 @@ class Complexity(Metric):
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 
-    # TODO. Only bool for return_aggreate..
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/complexity/complexity.py
+++ b/quantus/metrics/complexity/complexity.py
@@ -15,7 +15,12 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class Complexity(Metric):
@@ -140,8 +145,8 @@ class Complexity(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -174,7 +179,7 @@ class Complexity(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/complexity/complexity.py
+++ b/quantus/metrics/complexity/complexity.py
@@ -15,7 +15,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class Complexity(Metric):
@@ -36,13 +36,14 @@ class Complexity(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Complexity"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
-
+    _evaluation_category = EvaluationCategory.COMPLEXITY
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/complexity/effective_complexity.py
+++ b/quantus/metrics/complexity/effective_complexity.py
@@ -14,6 +14,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class EffectiveComplexity(Metric):
@@ -26,7 +27,23 @@ class EffectiveComplexity(Metric):
     References:
         1) An-phi Nguyen and María Rodríguez Martínez.: "On quantitative aspects of model
         interpretability." arXiv preprint arXiv:2007.07584 (2020).
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Effective Complexity"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/complexity/effective_complexity.py
+++ b/quantus/metrics/complexity/effective_complexity.py
@@ -32,15 +32,15 @@ class EffectiveComplexity(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Effective Complexity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.COMPLEXITY
+    name = "Effective Complexity"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.COMPLEXITY
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/complexity/effective_complexity.py
+++ b/quantus/metrics/complexity/effective_complexity.py
@@ -36,7 +36,7 @@ class EffectiveComplexity(Metric):
     """
 
     _name = "Effective Complexity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/complexity/effective_complexity.py
+++ b/quantus/metrics/complexity/effective_complexity.py
@@ -14,7 +14,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class EffectiveComplexity(Metric):
@@ -33,12 +33,14 @@ class EffectiveComplexity(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Effective Complexity"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.COMPLEXITY
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/complexity/effective_complexity.py
+++ b/quantus/metrics/complexity/effective_complexity.py
@@ -36,12 +36,7 @@ class EffectiveComplexity(Metric):
     """
 
     _name = "Effective Complexity"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/complexity/effective_complexity.py
+++ b/quantus/metrics/complexity/effective_complexity.py
@@ -14,7 +14,12 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class EffectiveComplexity(Metric):
@@ -143,8 +148,8 @@ class EffectiveComplexity(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -177,7 +182,7 @@ class EffectiveComplexity(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/complexity/sparseness.py
+++ b/quantus/metrics/complexity/sparseness.py
@@ -14,6 +14,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class Sparseness(Metric):
@@ -31,7 +32,23 @@ class Sparseness(Metric):
     References:
         1) Prasad Chalasani et al.: "Concise explanations of neural networks using adversarial training."
         International Conference on Machine Learning. PMLR, 2020.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Sparseness"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/complexity/sparseness.py
+++ b/quantus/metrics/complexity/sparseness.py
@@ -41,12 +41,7 @@ class Sparseness(Metric):
     """
 
     _name = "Sparseness"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/complexity/sparseness.py
+++ b/quantus/metrics/complexity/sparseness.py
@@ -41,7 +41,7 @@ class Sparseness(Metric):
     """
 
     _name = "Sparseness"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/complexity/sparseness.py
+++ b/quantus/metrics/complexity/sparseness.py
@@ -37,15 +37,15 @@ class Sparseness(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Sparseness"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.COMPLEXITY
+    name = "Sparseness"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.COMPLEXITY
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/complexity/sparseness.py
+++ b/quantus/metrics/complexity/sparseness.py
@@ -14,7 +14,12 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class Sparseness(Metric):
@@ -145,8 +150,8 @@ class Sparseness(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -179,7 +184,7 @@ class Sparseness(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/complexity/sparseness.py
+++ b/quantus/metrics/complexity/sparseness.py
@@ -14,7 +14,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class Sparseness(Metric):
@@ -38,12 +38,14 @@ class Sparseness(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Sparseness"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.COMPLEXITY
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/faithfulness_correlation.py
+++ b/quantus/metrics/faithfulness/faithfulness_correlation.py
@@ -17,7 +17,12 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.functions.similarity_func import correlation_pearson
 from quantus.metrics.base_perturbed import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class FaithfulnessCorrelation(PerturbationMetric):
@@ -186,8 +191,8 @@ class FaithfulnessCorrelation(PerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -223,7 +228,7 @@ class FaithfulnessCorrelation(PerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/faithfulness/faithfulness_correlation.py
+++ b/quantus/metrics/faithfulness/faithfulness_correlation.py
@@ -16,8 +16,8 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.functions.similarity_func import correlation_pearson
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class FaithfulnessCorrelation(PerturbationMetric):
@@ -46,12 +46,14 @@ class FaithfulnessCorrelation(PerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Faithfulness Correlation"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/faithfulness_correlation.py
+++ b/quantus/metrics/faithfulness/faithfulness_correlation.py
@@ -17,6 +17,7 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.functions.similarity_func import correlation_pearson
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class FaithfulnessCorrelation(PerturbationMetric):
@@ -40,7 +41,17 @@ class FaithfulnessCorrelation(PerturbationMetric):
         1) Umang Bhatt et al.: "Evaluating and aggregating feature-based model
         explanations." IJCAI (2020): 3016-3022.
 
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Faithfulness Correlation"
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/faithfulness_correlation.py
+++ b/quantus/metrics/faithfulness/faithfulness_correlation.py
@@ -49,7 +49,7 @@ class FaithfulnessCorrelation(PerturbationMetric):
     """
 
     _name = "Faithfulness Correlation"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/faithfulness/faithfulness_correlation.py
+++ b/quantus/metrics/faithfulness/faithfulness_correlation.py
@@ -45,15 +45,15 @@ class FaithfulnessCorrelation(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Faithfulness Correlation"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.FAITHFULNESS
+    name = "Faithfulness Correlation"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/faithfulness_estimate.py
+++ b/quantus/metrics/faithfulness/faithfulness_estimate.py
@@ -17,7 +17,12 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.functions.similarity_func import correlation_pearson
 from quantus.metrics.base_perturbed import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class FaithfulnessEstimate(PerturbationMetric):
@@ -171,8 +176,8 @@ class FaithfulnessEstimate(PerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -208,7 +213,7 @@ class FaithfulnessEstimate(PerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/faithfulness/faithfulness_estimate.py
+++ b/quantus/metrics/faithfulness/faithfulness_estimate.py
@@ -16,8 +16,8 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.functions.similarity_func import correlation_pearson
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class FaithfulnessEstimate(PerturbationMetric):
@@ -36,12 +36,14 @@ class FaithfulnessEstimate(PerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Faithfulness Estimate"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/faithfulness_estimate.py
+++ b/quantus/metrics/faithfulness/faithfulness_estimate.py
@@ -39,7 +39,7 @@ class FaithfulnessEstimate(PerturbationMetric):
     """
 
     _name = "Faithfulness Estimate"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/faithfulness/faithfulness_estimate.py
+++ b/quantus/metrics/faithfulness/faithfulness_estimate.py
@@ -17,6 +17,7 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.functions.similarity_func import correlation_pearson
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class FaithfulnessEstimate(PerturbationMetric):
@@ -29,7 +30,18 @@ class FaithfulnessEstimate(PerturbationMetric):
     References:
         1) David Alvarez-Melis and Tommi S. Jaakkola.: "Towards robust interpretability with self-explaining
         neural networks." NeurIPS (2018): 7786-7795.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Faithfulness Estimate"
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/faithfulness_estimate.py
+++ b/quantus/metrics/faithfulness/faithfulness_estimate.py
@@ -35,15 +35,15 @@ class FaithfulnessEstimate(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Faithfulness Estimate"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.FAITHFULNESS
+    name = "Faithfulness Estimate"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/infidelity.py
+++ b/quantus/metrics/faithfulness/infidelity.py
@@ -17,6 +17,7 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class Infidelity(PerturbationMetric):
@@ -32,14 +33,25 @@ class Infidelity(PerturbationMetric):
         blob/master/infid_sen_utils.py) supports perturbation of Gaussian noise and squared patches.
         In this implementation, we use squared patches as the default option.
         - Since we use squared patches in this implementation, the metric is only applicable
-        to 3-dimensional (image) data. To extend the applicablity to other data domains, adjustments
+        to 3-dimensional (image) data. To extend the applicability to other data domains, adjustments
         to the current implementation might be necessary.
 
     References:
         1) Chih-Kuan Yeh et al.:
         "On the (In)fidelity and Sensitivity of Explanations."
         33rd Conference on Neural Information Processing Systems (NeurIPS 2019), Vancouver, Canada.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Infidelity"
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/infidelity.py
+++ b/quantus/metrics/faithfulness/infidelity.py
@@ -45,15 +45,15 @@ class Infidelity(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Infidelity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.FAITHFULNESS
+    name = "Infidelity"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/infidelity.py
+++ b/quantus/metrics/faithfulness/infidelity.py
@@ -49,7 +49,7 @@ class Infidelity(PerturbationMetric):
     """
 
     _name = "Infidelity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/faithfulness/infidelity.py
+++ b/quantus/metrics/faithfulness/infidelity.py
@@ -16,8 +16,8 @@ from quantus.functions.loss_func import mse
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class Infidelity(PerturbationMetric):
@@ -46,12 +46,14 @@ class Infidelity(PerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Infidelity"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/infidelity.py
+++ b/quantus/metrics/faithfulness/infidelity.py
@@ -17,7 +17,12 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base_perturbed import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class Infidelity(PerturbationMetric):
@@ -196,8 +201,8 @@ class Infidelity(PerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -230,7 +235,7 @@ class Infidelity(PerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/faithfulness/irof.py
+++ b/quantus/metrics/faithfulness/irof.py
@@ -16,8 +16,8 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class IROF(PerturbationMetric):
@@ -42,12 +42,14 @@ class IROF(PerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "IROF"
     _data_applicability = {DataType.IMAGE}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/irof.py
+++ b/quantus/metrics/faithfulness/irof.py
@@ -41,15 +41,15 @@ class IROF(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "IROF"
-    _data_applicability = {DataType.IMAGE}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.FAITHFULNESS
+    name = "IROF"
+    data_applicability = {DataType.IMAGE}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/irof.py
+++ b/quantus/metrics/faithfulness/irof.py
@@ -17,6 +17,7 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class IROF(PerturbationMetric):
@@ -36,7 +37,17 @@ class IROF(PerturbationMetric):
         1) Laura Rieger and Lars Kai Hansen. "Irof: a low resource evaluation metric for
         explanation methods." arXiv preprint arXiv:2003.08747 (2020).
 
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "IROF"
+    _data_applicability = {DataType.IMAGE}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/irof.py
+++ b/quantus/metrics/faithfulness/irof.py
@@ -17,7 +17,12 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base_perturbed import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class IROF(PerturbationMetric):
@@ -175,8 +180,8 @@ class IROF(PerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -209,7 +214,7 @@ class IROF(PerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:
@@ -374,4 +379,4 @@ class IROF(PerturbationMetric):
     @property
     def get_aoc_score(self):
         """Calculate the area over the curve (AOC) score for several test samples."""
-        return np.mean(self.last_results)
+        return np.mean(self.evaluation_scores)

--- a/quantus/metrics/faithfulness/monotonicity.py
+++ b/quantus/metrics/faithfulness/monotonicity.py
@@ -46,12 +46,7 @@ class Monotonicity(PerturbationMetric):
     """
 
     _name = "Monotonicity"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/faithfulness/monotonicity.py
+++ b/quantus/metrics/faithfulness/monotonicity.py
@@ -46,7 +46,7 @@ class Monotonicity(PerturbationMetric):
     """
 
     _name = "Monotonicity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/faithfulness/monotonicity.py
+++ b/quantus/metrics/faithfulness/monotonicity.py
@@ -17,7 +17,12 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base_perturbed import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class Monotonicity(PerturbationMetric):
@@ -171,8 +176,8 @@ class Monotonicity(PerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -205,7 +210,7 @@ class Monotonicity(PerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/faithfulness/monotonicity.py
+++ b/quantus/metrics/faithfulness/monotonicity.py
@@ -16,8 +16,8 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class Monotonicity(PerturbationMetric):
@@ -43,12 +43,14 @@ class Monotonicity(PerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Monotonicity"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/monotonicity.py
+++ b/quantus/metrics/faithfulness/monotonicity.py
@@ -17,13 +17,14 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class Monotonicity(PerturbationMetric):
     """
     Implementation of Monotonicity metric by Arya at el., 2019.
 
-    Montonicity tests if adding more positive evidence increases the probability
+    Monotonicity tests if adding more positive evidence increases the probability
     of classification in the specified class.
 
     It captures attributions' faithfulness by incrementally adding each attribute
@@ -36,7 +37,23 @@ class Monotonicity(PerturbationMetric):
         techniques." arXiv preprint arXiv:1909.03012 (2019).
         2) Ronny Luss et al.: "Generating contrastive explanations with monotonic attribute functions."
         arXiv preprint arXiv:1905.12698 (2019).
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Monotonicity"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/monotonicity.py
+++ b/quantus/metrics/faithfulness/monotonicity.py
@@ -42,15 +42,15 @@ class Monotonicity(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Monotonicity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.FAITHFULNESS
+    name = "Monotonicity"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/monotonicity_correlation.py
+++ b/quantus/metrics/faithfulness/monotonicity_correlation.py
@@ -36,19 +36,19 @@ class MonotonicityCorrelation(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Monotonicity"
-    _data_applicability = {
+    name = "Monotonicity"
+    data_applicability = {
         DataType.IMAGE,
         DataType.TIMESERIES,
         DataType.TABULAR,
     }
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.FAITHFULNESS
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/monotonicity_correlation.py
+++ b/quantus/metrics/faithfulness/monotonicity_correlation.py
@@ -43,7 +43,7 @@ class MonotonicityCorrelation(PerturbationMetric):
     _data_applicability = {
         DataType.IMAGE,
         DataType.TIMESERIES,
-        DataType.TABLUAR,
+        DataType.TABULAR,
     }
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER

--- a/quantus/metrics/faithfulness/monotonicity_correlation.py
+++ b/quantus/metrics/faithfulness/monotonicity_correlation.py
@@ -44,7 +44,6 @@ class MonotonicityCorrelation(PerturbationMetric):
         DataType.IMAGE,
         DataType.TIMESERIES,
         DataType.TABLUAR,
-        DataType.TEXT,
     }
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER

--- a/quantus/metrics/faithfulness/monotonicity_correlation.py
+++ b/quantus/metrics/faithfulness/monotonicity_correlation.py
@@ -17,6 +17,7 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.functions.similarity_func import correlation_spearman
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class MonotonicityCorrelation(PerturbationMetric):
@@ -30,7 +31,23 @@ class MonotonicityCorrelation(PerturbationMetric):
     References:
         1) An-phi Nguyen and María Rodríguez Martínez.: "On quantitative aspects of model
         interpretability." arXiv preprint arXiv:2007.07584 (2020).
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Monotonicity"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(
@@ -287,7 +304,7 @@ class MonotonicityCorrelation(PerturbationMetric):
         y_pred = float(model.predict(x_input)[:, y])
 
         inv_pred = 1.0 if np.abs(y_pred) < self.eps else 1.0 / np.abs(y_pred)
-        inv_pred = inv_pred**2
+        inv_pred = inv_pred ** 2
 
         # Reshape attributions.
         a = a.flatten()

--- a/quantus/metrics/faithfulness/monotonicity_correlation.py
+++ b/quantus/metrics/faithfulness/monotonicity_correlation.py
@@ -17,7 +17,12 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.functions.similarity_func import correlation_spearman
 from quantus.metrics.base_perturbed import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class MonotonicityCorrelation(PerturbationMetric):
@@ -185,8 +190,8 @@ class MonotonicityCorrelation(PerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -222,7 +227,7 @@ class MonotonicityCorrelation(PerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/faithfulness/monotonicity_correlation.py
+++ b/quantus/metrics/faithfulness/monotonicity_correlation.py
@@ -16,8 +16,8 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.functions.similarity_func import correlation_spearman
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class MonotonicityCorrelation(PerturbationMetric):
@@ -37,6 +37,7 @@ class MonotonicityCorrelation(PerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Monotonicity"
@@ -47,6 +48,7 @@ class MonotonicityCorrelation(PerturbationMetric):
     }
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/pixel_flipping.py
+++ b/quantus/metrics/faithfulness/pixel_flipping.py
@@ -18,6 +18,7 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class PixelFlipping(PerturbationMetric):
@@ -32,7 +33,23 @@ class PixelFlipping(PerturbationMetric):
     References:
         1) Sebastian Bach et al.: "On pixel-wise explanations for non-linear classifier
         decisions by layer-wise relevance propagation." PloS one 10.7 (2015): e0130140.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Pixel-Flipping"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/pixel_flipping.py
+++ b/quantus/metrics/faithfulness/pixel_flipping.py
@@ -42,7 +42,7 @@ class PixelFlipping(PerturbationMetric):
     """
 
     _name = "Pixel-Flipping"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/faithfulness/pixel_flipping.py
+++ b/quantus/metrics/faithfulness/pixel_flipping.py
@@ -42,12 +42,7 @@ class PixelFlipping(PerturbationMetric):
     """
 
     _name = "Pixel-Flipping"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/faithfulness/pixel_flipping.py
+++ b/quantus/metrics/faithfulness/pixel_flipping.py
@@ -38,15 +38,15 @@ class PixelFlipping(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Pixel-Flipping"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.FAITHFULNESS
+    name = "Pixel-Flipping"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/pixel_flipping.py
+++ b/quantus/metrics/faithfulness/pixel_flipping.py
@@ -17,8 +17,8 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class PixelFlipping(PerturbationMetric):
@@ -39,12 +39,14 @@ class PixelFlipping(PerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Pixel-Flipping"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/pixel_flipping.py
+++ b/quantus/metrics/faithfulness/pixel_flipping.py
@@ -18,7 +18,12 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base_perturbed import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class PixelFlipping(PerturbationMetric):
@@ -172,8 +177,8 @@ class PixelFlipping(PerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -206,7 +211,7 @@ class PixelFlipping(PerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:
@@ -361,5 +366,5 @@ class PixelFlipping(PerturbationMetric):
     def get_auc_score(self):
         """Calculate the area under the curve (AUC) score for several test samples."""
         return np.mean(
-            [utils.calculate_auc(np.array(curve)) for curve in self.last_results]
+            [utils.calculate_auc(np.array(curve)) for curve in self.evaluation_scores]
         )

--- a/quantus/metrics/faithfulness/region_perturbation.py
+++ b/quantus/metrics/faithfulness/region_perturbation.py
@@ -18,8 +18,8 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class RegionPerturbation(PerturbationMetric):
@@ -46,12 +46,14 @@ class RegionPerturbation(PerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Region-Perturbation"
     _data_applicability = {DataType.IMAGE}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/region_perturbation.py
+++ b/quantus/metrics/faithfulness/region_perturbation.py
@@ -45,15 +45,15 @@ class RegionPerturbation(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Region-Perturbation"
-    _data_applicability = {DataType.IMAGE}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.FAITHFULNESS
+    name = "Region-Perturbation"
+    data_applicability = {DataType.IMAGE}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/region_perturbation.py
+++ b/quantus/metrics/faithfulness/region_perturbation.py
@@ -19,7 +19,12 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base_perturbed import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class RegionPerturbation(PerturbationMetric):
@@ -192,8 +197,8 @@ class RegionPerturbation(PerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -226,7 +231,7 @@ class RegionPerturbation(PerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:
@@ -417,5 +422,5 @@ class RegionPerturbation(PerturbationMetric):
     def get_auc_score(self):
         """Calculate the area under the curve (AUC) score for several test samples."""
         return np.mean(
-            [utils.calculate_auc(np.array(curve)) for curve in self.last_results]
+            [utils.calculate_auc(np.array(curve)) for curve in self.evaluation_scores]
         )

--- a/quantus/metrics/faithfulness/region_perturbation.py
+++ b/quantus/metrics/faithfulness/region_perturbation.py
@@ -19,6 +19,7 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class RegionPerturbation(PerturbationMetric):
@@ -39,7 +40,18 @@ class RegionPerturbation(PerturbationMetric):
         1) Wojciech Samek et al.: "Evaluating the visualization of what a deep
         neural network has learned." IEEE transactions on neural networks and
         learning systems 28.11 (2016): 2660-2673.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Region-Perturbation"
+    _data_applicability = {DataType.IMAGE}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/road.py
+++ b/quantus/metrics/faithfulness/road.py
@@ -16,6 +16,7 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import noisy_linear_imputation
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class ROAD(PerturbationMetric):
@@ -34,7 +35,18 @@ class ROAD(PerturbationMetric):
     References:
         1) Leemann Rong et al.: "Evaluating Feature Attribution: An Information-Theoretic Perspective." arXiv preprint
         arXiv:2202.00449 (2022).
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "ROAD"
+    _data_applicability = {DataType.IMAGE}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER  # Not sure.
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/road.py
+++ b/quantus/metrics/faithfulness/road.py
@@ -46,7 +46,7 @@ class ROAD(PerturbationMetric):
     _name = "ROAD"
     _data_applicability = {DataType.IMAGE}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER  # Not sure.
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/road.py
+++ b/quantus/metrics/faithfulness/road.py
@@ -16,7 +16,12 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import noisy_linear_imputation
 from quantus.metrics.base_perturbed import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class ROAD(PerturbationMetric):
@@ -175,8 +180,8 @@ class ROAD(PerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -209,7 +214,7 @@ class ROAD(PerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:
@@ -378,7 +383,7 @@ class ROAD(PerturbationMetric):
         """
 
         # Calculate accuracy for every number of most important pixels removed.
-        self.last_results = {
-            percentage: np.mean(np.array(self.last_results)[:, p_ix])
+        self.evaluation_scores = {
+            percentage: np.mean(np.array(self.evaluation_scores)[:, p_ix])
             for p_ix, percentage in enumerate(self.percentages)
         }

--- a/quantus/metrics/faithfulness/road.py
+++ b/quantus/metrics/faithfulness/road.py
@@ -15,8 +15,8 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import noisy_linear_imputation
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class ROAD(PerturbationMetric):
@@ -41,12 +41,14 @@ class ROAD(PerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "ROAD"
     _data_applicability = {DataType.IMAGE}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/road.py
+++ b/quantus/metrics/faithfulness/road.py
@@ -40,15 +40,15 @@ class ROAD(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "ROAD"
-    _data_applicability = {DataType.IMAGE}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.FAITHFULNESS
+    name = "ROAD"
+    data_applicability = {DataType.IMAGE}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/selectivity.py
+++ b/quantus/metrics/faithfulness/selectivity.py
@@ -19,6 +19,7 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class Selectivity(PerturbationMetric):
@@ -39,7 +40,18 @@ class Selectivity(PerturbationMetric):
         1) Grégoire Montavon et al.:
         "Methods for interpreting and understanding deep neural networks."
         Digital Signal Processing 73 (2018): 1-15.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Selectivity"
+    _data_applicability = {DataType.IMAGE}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(
@@ -348,7 +360,6 @@ class Selectivity(PerturbationMetric):
             x_perturbed = utils._unpad_array(
                 x_perturbed_pad, pad_width, padded_axes=self.a_axes
             )
-
             warn.warn_perturbation_caused_no_change(x=x, x_perturbed=x_perturbed)
 
             # Predict on perturbed input x and store the difference from predicting on unperturbed input.

--- a/quantus/metrics/faithfulness/selectivity.py
+++ b/quantus/metrics/faithfulness/selectivity.py
@@ -18,8 +18,8 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class Selectivity(PerturbationMetric):
@@ -46,12 +46,14 @@ class Selectivity(PerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Selectivity"
     _data_applicability = {DataType.IMAGE}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/selectivity.py
+++ b/quantus/metrics/faithfulness/selectivity.py
@@ -19,7 +19,12 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.metrics.base_perturbed import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class Selectivity(PerturbationMetric):
@@ -181,8 +186,8 @@ class Selectivity(PerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -215,7 +220,7 @@ class Selectivity(PerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:
@@ -378,6 +383,6 @@ class Selectivity(PerturbationMetric):
         return np.mean(
             [
                 utils.calculate_auc(np.array(curve))
-                for i, curve in enumerate(self.last_results)
+                for i, curve in enumerate(self.evaluation_scores)
             ]
         )

--- a/quantus/metrics/faithfulness/selectivity.py
+++ b/quantus/metrics/faithfulness/selectivity.py
@@ -45,15 +45,15 @@ class Selectivity(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Selectivity"
-    _data_applicability = {DataType.IMAGE}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.FAITHFULNESS
+    name = "Selectivity"
+    data_applicability = {DataType.IMAGE}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/sensitivity_n.py
+++ b/quantus/metrics/faithfulness/sensitivity_n.py
@@ -17,8 +17,8 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.functions.similarity_func import correlation_pearson
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class SensitivityN(PerturbationMetric):
@@ -42,12 +42,14 @@ class SensitivityN(PerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Sensitivity-N"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/sensitivity_n.py
+++ b/quantus/metrics/faithfulness/sensitivity_n.py
@@ -41,15 +41,15 @@ class SensitivityN(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Sensitivity-N"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.FAITHFULNESS
+    name = "Sensitivity-N"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/sensitivity_n.py
+++ b/quantus/metrics/faithfulness/sensitivity_n.py
@@ -45,7 +45,7 @@ class SensitivityN(PerturbationMetric):
     """
 
     _name = "Sensitivity-N"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/faithfulness/sensitivity_n.py
+++ b/quantus/metrics/faithfulness/sensitivity_n.py
@@ -18,6 +18,7 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import baseline_replacement_by_indices
 from quantus.functions.similarity_func import correlation_pearson
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class SensitivityN(PerturbationMetric):
@@ -36,7 +37,22 @@ class SensitivityN(PerturbationMetric):
         1) Marco Ancona et al.: "Towards better understanding of gradient-based attribution
         methods for deep neural networks." ICLR (Poster) (2018).
 
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Sensitivity-N"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/sensitivity_n.py
+++ b/quantus/metrics/faithfulness/sensitivity_n.py
@@ -45,12 +45,7 @@ class SensitivityN(PerturbationMetric):
     """
 
     _name = "Sensitivity-N"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/faithfulness/sufficiency.py
+++ b/quantus/metrics/faithfulness/sufficiency.py
@@ -44,14 +44,9 @@ class Sufficiency(Metric):
     """
 
     _name = "Sufficiency"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER  # Not sure.
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(
@@ -337,8 +332,8 @@ class Sufficiency(Metric):
         x_input = model.shape_input(
             x_batch, x_batch[0].shape, channel_first=True, batched=True
         )
-
         y_pred_classes = np.argmax(model.predict(x_input), axis=1).flatten()
+
         return {
             "i_batch": np.arange(x_batch.shape[0]),
             "a_sim_vector_batch": a_sim_matrix,

--- a/quantus/metrics/faithfulness/sufficiency.py
+++ b/quantus/metrics/faithfulness/sufficiency.py
@@ -16,7 +16,12 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class Sufficiency(Metric):
@@ -159,8 +164,8 @@ class Sufficiency(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -193,7 +198,7 @@ class Sufficiency(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/faithfulness/sufficiency.py
+++ b/quantus/metrics/faithfulness/sufficiency.py
@@ -44,7 +44,7 @@ class Sufficiency(Metric):
     """
 
     _name = "Sufficiency"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/faithfulness/sufficiency.py
+++ b/quantus/metrics/faithfulness/sufficiency.py
@@ -16,7 +16,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class Sufficiency(Metric):
@@ -41,12 +41,14 @@ class Sufficiency(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Sufficiency"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/sufficiency.py
+++ b/quantus/metrics/faithfulness/sufficiency.py
@@ -40,15 +40,15 @@ class Sufficiency(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Sufficiency"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.FAITHFULNESS
+    name = "Sufficiency"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.FAITHFULNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/faithfulness/sufficiency.py
+++ b/quantus/metrics/faithfulness/sufficiency.py
@@ -16,6 +16,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class Sufficiency(Metric):
@@ -34,7 +35,23 @@ class Sufficiency(Metric):
     References:
          1) Sanjoy Dasgupta et al.: "Framework for Evaluating Faithfulness of Local
             Explanations." ICML (2022): 4794-4815.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Sufficiency"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER  # Not sure.
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/attribution_localisation.py
+++ b/quantus/metrics/localisation/attribution_localisation.py
@@ -14,7 +14,12 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class AttributionLocalisation(Metric):
@@ -153,8 +158,8 @@ class AttributionLocalisation(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -187,7 +192,7 @@ class AttributionLocalisation(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/localisation/attribution_localisation.py
+++ b/quantus/metrics/localisation/attribution_localisation.py
@@ -14,7 +14,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class AttributionLocalisation(Metric):
@@ -34,12 +34,14 @@ class AttributionLocalisation(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Attribution Localisation"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/attribution_localisation.py
+++ b/quantus/metrics/localisation/attribution_localisation.py
@@ -14,6 +14,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class AttributionLocalisation(Metric):
@@ -25,11 +26,25 @@ class AttributionLocalisation(Metric):
     targeted object class.
 
     References:
-        1) Max Kohlbrenner et al.:
-           "Towards Best Practice in Explaining Neural Network Decisions with LRP."
+        1) Max Kohlbrenner et al., "Towards Best Practice in Explaining Neural Network Decisions with LRP."
            IJCNN (2020): 1-7.
 
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Attribution Localisation"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/attribution_localisation.py
+++ b/quantus/metrics/localisation/attribution_localisation.py
@@ -37,12 +37,7 @@ class AttributionLocalisation(Metric):
     """
 
     _name = "Attribution Localisation"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/localisation/attribution_localisation.py
+++ b/quantus/metrics/localisation/attribution_localisation.py
@@ -33,15 +33,15 @@ class AttributionLocalisation(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Attribution Localisation"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.LOCALISATION
+    name = "Attribution Localisation"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/attribution_localisation.py
+++ b/quantus/metrics/localisation/attribution_localisation.py
@@ -37,7 +37,7 @@ class AttributionLocalisation(Metric):
     """
 
     _name = "Attribution Localisation"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/localisation/auc.py
+++ b/quantus/metrics/localisation/auc.py
@@ -35,12 +35,7 @@ class AUC(Metric):
     """
 
     _name = "AUC"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/localisation/auc.py
+++ b/quantus/metrics/localisation/auc.py
@@ -35,7 +35,7 @@ class AUC(Metric):
     """
 
     _name = "AUC"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/localisation/auc.py
+++ b/quantus/metrics/localisation/auc.py
@@ -15,6 +15,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class AUC(Metric):
@@ -26,7 +27,22 @@ class AUC(Metric):
     References:
         1) Tom Fawcett: 'An introduction to ROC analysis' "Pattern Recognition Letters" Vol 27, Issue 8, 2006
 
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "AUC"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/auc.py
+++ b/quantus/metrics/localisation/auc.py
@@ -15,7 +15,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class AUC(Metric):
@@ -32,12 +32,14 @@ class AUC(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "AUC"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/auc.py
+++ b/quantus/metrics/localisation/auc.py
@@ -31,15 +31,15 @@ class AUC(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "AUC"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.LOCALISATION
+    name = "AUC"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/auc.py
+++ b/quantus/metrics/localisation/auc.py
@@ -15,7 +15,12 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class AUC(Metric):
@@ -133,8 +138,8 @@ class AUC(Metric):
             output labels (y_batch) and a torch or tensorflow model (model).
 
             Calls general_preprocess() with all relevant arguments, calls
-            () on each instance, and saves results to last_results.
-            Calls custom_postprocess() afterwards. Finally returns last_results.
+            () on each instance, and saves results to evaluation_scores.
+            Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
             Parameters
             ----------
@@ -165,7 +170,7 @@ class AUC(Metric):
 
             Returns
             -------
-        last_results: list
+        evaluation_scores: list
                 a list of Any with the evaluation scores of the concerned batch.
 
             Examples:

--- a/quantus/metrics/localisation/focus.py
+++ b/quantus/metrics/localisation/focus.py
@@ -15,6 +15,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class Focus(Metric):
@@ -31,7 +32,18 @@ class Focus(Metric):
     References:
         1) Anna Arias-Duart et al.: "Focus! Rating XAI Methods
         and Finding Biases" FUZZ-IEEE (2022): 1-8.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Focus"
+    _data_applicability = {DataType.IMAGE}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/focus.py
+++ b/quantus/metrics/localisation/focus.py
@@ -15,7 +15,12 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class Focus(Metric):
@@ -145,8 +150,8 @@ class Focus(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         For this metric to run we need to get the positions of the target class within the mosaic.
         This should be a np.ndarray containing one tuple per sample, representing the positions
@@ -209,7 +214,7 @@ class Focus(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/localisation/focus.py
+++ b/quantus/metrics/localisation/focus.py
@@ -15,7 +15,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class Focus(Metric):
@@ -38,12 +38,14 @@ class Focus(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Focus"
     _data_applicability = {DataType.IMAGE}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/focus.py
+++ b/quantus/metrics/localisation/focus.py
@@ -37,15 +37,15 @@ class Focus(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Focus"
-    _data_applicability = {DataType.IMAGE}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.LOCALISATION
+    name = "Focus"
+    data_applicability = {DataType.IMAGE}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/pointing_game.py
+++ b/quantus/metrics/localisation/pointing_game.py
@@ -14,6 +14,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class PointingGame(Metric):
@@ -29,7 +30,22 @@ class PointingGame(Metric):
            "Top-Down Neural Attention by Excitation Backprop." International Journal of Computer Vision
            (2018) 126:1084-1102.
 
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Pointing-Game"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/pointing_game.py
+++ b/quantus/metrics/localisation/pointing_game.py
@@ -38,12 +38,7 @@ class PointingGame(Metric):
     """
 
     _name = "Pointing-Game"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/localisation/pointing_game.py
+++ b/quantus/metrics/localisation/pointing_game.py
@@ -38,7 +38,7 @@ class PointingGame(Metric):
     """
 
     _name = "Pointing-Game"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/localisation/pointing_game.py
+++ b/quantus/metrics/localisation/pointing_game.py
@@ -14,7 +14,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class PointingGame(Metric):
@@ -41,6 +41,7 @@ class PointingGame(Metric):
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/pointing_game.py
+++ b/quantus/metrics/localisation/pointing_game.py
@@ -34,14 +34,14 @@ class PointingGame(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
 
-    _name = "Pointing-Game"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.LOCALISATION
+    name = "Pointing-Game"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/pointing_game.py
+++ b/quantus/metrics/localisation/pointing_game.py
@@ -14,7 +14,12 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class PointingGame(Metric):
@@ -143,8 +148,8 @@ class PointingGame(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -177,7 +182,7 @@ class PointingGame(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/localisation/relevance_mass_accuracy.py
+++ b/quantus/metrics/localisation/relevance_mass_accuracy.py
@@ -14,7 +14,12 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class RelevanceMassAccuracy(Metric):
@@ -137,8 +142,8 @@ class RelevanceMassAccuracy(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -171,7 +176,7 @@ class RelevanceMassAccuracy(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/localisation/relevance_mass_accuracy.py
+++ b/quantus/metrics/localisation/relevance_mass_accuracy.py
@@ -33,15 +33,15 @@ class RelevanceMassAccuracy(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Relevance Mass Accuracy"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.LOCALISATION
+    name = "Relevance Mass Accuracy"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/relevance_mass_accuracy.py
+++ b/quantus/metrics/localisation/relevance_mass_accuracy.py
@@ -37,12 +37,7 @@ class RelevanceMassAccuracy(Metric):
     """
 
     _name = "Relevance Mass Accuracy"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/localisation/relevance_mass_accuracy.py
+++ b/quantus/metrics/localisation/relevance_mass_accuracy.py
@@ -37,7 +37,7 @@ class RelevanceMassAccuracy(Metric):
     """
 
     _name = "Relevance Mass Accuracy"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/localisation/relevance_mass_accuracy.py
+++ b/quantus/metrics/localisation/relevance_mass_accuracy.py
@@ -14,11 +14,12 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class RelevanceMassAccuracy(Metric):
     """
-    Implementation of the Relevance Rank Accuracy by Arras et al., 2021.
+    Implementation of the Relevance Mass Accuracy by Arras et al., 2021.
 
     The Relevance Mass Accuracy computes the ratio of attributions inside the bounding box to
     the sum of overall positive attributions. High scores are desired, as the pixels with the highest positively
@@ -27,7 +28,23 @@ class RelevanceMassAccuracy(Metric):
     References:
         1) Leila Arras et al.: "CLEVR-XAI: A benchmark dataset for the ground
         truth evaluation of neural network explanations." Inf. Fusion 81 (2022): 14-40.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Relevance Mass Accuracy"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/relevance_mass_accuracy.py
+++ b/quantus/metrics/localisation/relevance_mass_accuracy.py
@@ -14,7 +14,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class RelevanceMassAccuracy(Metric):
@@ -34,12 +34,14 @@ class RelevanceMassAccuracy(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Relevance Mass Accuracy"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/relevance_rank_accuracy.py
+++ b/quantus/metrics/localisation/relevance_rank_accuracy.py
@@ -39,7 +39,7 @@ class RelevanceRankAccuracy(Metric):
     """
 
     _name = "Relevance Rank Accuracy"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/localisation/relevance_rank_accuracy.py
+++ b/quantus/metrics/localisation/relevance_rank_accuracy.py
@@ -39,12 +39,7 @@ class RelevanceRankAccuracy(Metric):
     """
 
     _name = "Relevance Rank Accuracy"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/localisation/relevance_rank_accuracy.py
+++ b/quantus/metrics/localisation/relevance_rank_accuracy.py
@@ -14,6 +14,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class RelevanceRankAccuracy(Metric):
@@ -29,7 +30,23 @@ class RelevanceRankAccuracy(Metric):
     References:
         1) Leila Arras et al.: "CLEVR-XAI: A benchmark dataset for the ground
         truth evaluation of neural network explanations." Inf. Fusion 81 (2022): 14-40.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Relevance Rank Accuracy"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/relevance_rank_accuracy.py
+++ b/quantus/metrics/localisation/relevance_rank_accuracy.py
@@ -35,15 +35,15 @@ class RelevanceRankAccuracy(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Relevance Rank Accuracy"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.LOCALISATION
+    name = "Relevance Rank Accuracy"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/relevance_rank_accuracy.py
+++ b/quantus/metrics/localisation/relevance_rank_accuracy.py
@@ -14,7 +14,12 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class RelevanceRankAccuracy(Metric):
@@ -139,8 +144,8 @@ class RelevanceRankAccuracy(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -173,7 +178,7 @@ class RelevanceRankAccuracy(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/localisation/relevance_rank_accuracy.py
+++ b/quantus/metrics/localisation/relevance_rank_accuracy.py
@@ -14,7 +14,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class RelevanceRankAccuracy(Metric):
@@ -36,12 +36,14 @@ class RelevanceRankAccuracy(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Relevance Rank Accuracy"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/top_k_intersection.py
+++ b/quantus/metrics/localisation/top_k_intersection.py
@@ -14,7 +14,12 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class TopKIntersection(Metric):
@@ -148,8 +153,8 @@ class TopKIntersection(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -182,7 +187,7 @@ class TopKIntersection(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/localisation/top_k_intersection.py
+++ b/quantus/metrics/localisation/top_k_intersection.py
@@ -37,12 +37,7 @@ class TopKIntersection(Metric):
     """
 
     _name = "Top-K Intersection"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/localisation/top_k_intersection.py
+++ b/quantus/metrics/localisation/top_k_intersection.py
@@ -37,7 +37,7 @@ class TopKIntersection(Metric):
     """
 
     _name = "Top-K Intersection"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
 

--- a/quantus/metrics/localisation/top_k_intersection.py
+++ b/quantus/metrics/localisation/top_k_intersection.py
@@ -33,15 +33,15 @@ class TopKIntersection(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Top-K Intersection"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.HIGHER
-    _evaluation_category = EvaluationCategory.LOCALISATION
+    name = "Top-K Intersection"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.HIGHER
+    evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/top_k_intersection.py
+++ b/quantus/metrics/localisation/top_k_intersection.py
@@ -14,6 +14,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class TopKIntersection(Metric):
@@ -27,7 +28,23 @@ class TopKIntersection(Metric):
     References:
         1) Jonas Theiner et al.: "Interpretable Semantic Photo
         Geolocalization." arXiv preprint arXiv:2104.14995 (2021).
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Top-K Intersection"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.HIGHER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/localisation/top_k_intersection.py
+++ b/quantus/metrics/localisation/top_k_intersection.py
@@ -14,7 +14,7 @@ from quantus.helpers import warn
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class TopKIntersection(Metric):
@@ -34,12 +34,14 @@ class TopKIntersection(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Top-K Intersection"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.HIGHER
+    _evaluation_category = EvaluationCategory.LOCALISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/randomisation/model_parameter_randomisation.py
+++ b/quantus/metrics/randomisation/model_parameter_randomisation.py
@@ -26,7 +26,7 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.similarity_func import correlation_spearman
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class ModelParameterRandomisation(Metric):
@@ -49,12 +49,14 @@ class ModelParameterRandomisation(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Model Parameter Randomisation"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.RANDOMISATION
 
     @asserts.attributes_check
     def __init__(
@@ -309,7 +311,7 @@ class ModelParameterRandomisation(Metric):
             # Save similarity scores in a result dictionary.
             self.last_results[layer_name] = similarity_scores
 
-        # Call post-processing
+        # Call post-processing.
         self.custom_postprocess(
             model=model,
             x_batch=x_batch,

--- a/quantus/metrics/randomisation/model_parameter_randomisation.py
+++ b/quantus/metrics/randomisation/model_parameter_randomisation.py
@@ -26,6 +26,7 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.similarity_func import correlation_spearman
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class ModelParameterRandomisation(Metric):
@@ -41,9 +42,24 @@ class ModelParameterRandomisation(Metric):
         HOG and SSIM. We have set Spearman as the default value.
 
     References:
-        1) Julius Adebayo et al.: "Sanity Checks for Saliency Maps."
-        NeurIPS (2018): 9525-9536.
+        1) Julius Adebayo et al.: "Sanity Checks for Saliency Maps." NeurIPS (2018): 9525-9536.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Model Parameter Randomisation"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(
@@ -67,8 +83,7 @@ class ModelParameterRandomisation(Metric):
         Parameters
         ----------
         similarity_func: callable
-            Similarity function applied to compare input and perturbed input,
-            default=correlation_spearman.
+            Similarity function applied to compare input and perturbed input, default=correlation_spearman.
         layer_order: string
             Indicated whether the model is randomized cascadingly or independently.
             Set order=top_down for cascading randomization, set order=independent for independent randomization,

--- a/quantus/metrics/randomisation/model_parameter_randomisation.py
+++ b/quantus/metrics/randomisation/model_parameter_randomisation.py
@@ -52,12 +52,7 @@ class ModelParameterRandomisation(Metric):
     """
 
     _name = "Model Parameter Randomisation"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/randomisation/model_parameter_randomisation.py
+++ b/quantus/metrics/randomisation/model_parameter_randomisation.py
@@ -26,7 +26,12 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.similarity_func import correlation_spearman
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class ModelParameterRandomisation(Metric):
@@ -137,7 +142,7 @@ class ModelParameterRandomisation(Metric):
         self.return_sample_correlation = return_sample_correlation
 
         # Results are returned/saved as a dictionary not like in the super-class as a list.
-        self.last_results = {}
+        self.evaluation_scores = {}
 
         # Asserts and warnings.
         asserts.assert_layer_order(layer_order=self.layer_order)
@@ -178,10 +183,10 @@ class ModelParameterRandomisation(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
-        The content of last_results will be appended to all_results (list) at the end of
+        The content of evaluation_scores will be appended to all_evaluation_scores (list) at the end of
         the evaluation call.
 
         Parameters
@@ -215,7 +220,7 @@ class ModelParameterRandomisation(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:
@@ -273,7 +278,7 @@ class ModelParameterRandomisation(Metric):
         a_batch = data["a_batch"]
 
         # Results are returned/saved as a dictionary not as a list as in the super-class.
-        self.last_results = {}
+        self.evaluation_scores = {}
 
         # Get number of iterations from number of layers.
         n_layers = len(list(model.get_random_layer_generator(order=self.layer_order)))
@@ -309,7 +314,7 @@ class ModelParameterRandomisation(Metric):
                 similarity_scores[instance_id] = result
 
             # Save similarity scores in a result dictionary.
-            self.last_results[layer_name] = similarity_scores
+            self.evaluation_scores[layer_name] = similarity_scores
 
         # Call post-processing.
         self.custom_postprocess(
@@ -321,18 +326,18 @@ class ModelParameterRandomisation(Metric):
         )
 
         if self.return_sample_correlation:
-            self.last_results = self.compute_correlation_per_sample()
+            self.evaluation_scores = self.compute_correlation_per_sample()
 
         if self.return_aggregate:
             assert self.return_sample_correlation, (
                 "You must set 'return_average_correlation_per_sample'"
                 " to True in order to compute te aggregat"
             )
-            self.last_results = [self.aggregate_func(self.last_results)]
+            self.evaluation_scores = [self.aggregate_func(self.evaluation_scores)]
 
-        self.all_results.append(self.last_results)
+        self.all_evaluation_scores.append(self.evaluation_scores)
 
-        return self.last_results
+        return self.evaluation_scores
 
     def evaluate_instance(
         self,
@@ -416,17 +421,19 @@ class ModelParameterRandomisation(Metric):
         self,
     ) -> Union[List[List[Any]], Dict[int, List[Any]]]:
 
-        assert isinstance(self.last_results, dict), (
+        assert isinstance(self.evaluation_scores, dict), (
             "To compute the average correlation coefficient per sample for "
             "Model Parameter Randomisation Test, 'last_result' "
             "must be of type dict."
         )
-        layer_length = len(self.last_results[list(self.last_results.keys())[0]])
+        layer_length = len(
+            self.evaluation_scores[list(self.evaluation_scores.keys())[0]]
+        )
         results: Dict[int, list] = {sample: [] for sample in range(layer_length)}
 
         for sample in results:
-            for layer in self.last_results:
-                results[sample].append(float(self.last_results[layer][sample]))
+            for layer in self.evaluation_scores:
+                results[sample].append(float(self.evaluation_scores[layer][sample]))
             results[sample] = np.mean(results[sample])
 
         corr_coeffs = list(results.values())

--- a/quantus/metrics/randomisation/model_parameter_randomisation.py
+++ b/quantus/metrics/randomisation/model_parameter_randomisation.py
@@ -48,15 +48,15 @@ class ModelParameterRandomisation(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Model Parameter Randomisation"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.RANDOMISATION
+    name = "Model Parameter Randomisation"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.RANDOMISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/randomisation/model_parameter_randomisation.py
+++ b/quantus/metrics/randomisation/model_parameter_randomisation.py
@@ -52,7 +52,7 @@ class ModelParameterRandomisation(Metric):
     """
 
     _name = "Model Parameter Randomisation"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/randomisation/random_logit.py
+++ b/quantus/metrics/randomisation/random_logit.py
@@ -37,7 +37,7 @@ class RandomLogit(Metric):
     """
 
     _name = "Random Logit"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/randomisation/random_logit.py
+++ b/quantus/metrics/randomisation/random_logit.py
@@ -33,15 +33,15 @@ class RandomLogit(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Random Logit"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.RANDOMISATION
+    name = "Random Logit"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.RANDOMISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/randomisation/random_logit.py
+++ b/quantus/metrics/randomisation/random_logit.py
@@ -37,12 +37,7 @@ class RandomLogit(Metric):
     """
 
     _name = "Random Logit"
-    _data_applicability = {
-        DataType.IMAGE,
-        DataType.TIMESERIES,
-        DataType.TABLUAR,
-        DataType.TEXT,
-    }
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/randomisation/random_logit.py
+++ b/quantus/metrics/randomisation/random_logit.py
@@ -15,6 +15,7 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.similarity_func import ssim
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class RandomLogit(Metric):
@@ -27,7 +28,23 @@ class RandomLogit(Metric):
     References:
         1) Leon Sixt et al.: "When Explanations Lie: Why Many Modified BP
         Attributions Fail." ICML (2020): 9046-9057.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Random Logit"
+    _data_applicability = {
+        DataType.IMAGE,
+        DataType.TIMESERIES,
+        DataType.TABLUAR,
+        DataType.TEXT,
+    }
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(
@@ -50,8 +67,7 @@ class RandomLogit(Metric):
         Parameters
         ----------
         similarity_func: callable
-            Similarity function applied to compare input and perturbed input,
-            default=ssim.
+            Similarity function applied to compare input and perturbed input, default=ssim.
         num_classes: integer
             Number of prediction classes in the input, default=1000.
         seed: integer

--- a/quantus/metrics/randomisation/random_logit.py
+++ b/quantus/metrics/randomisation/random_logit.py
@@ -15,7 +15,12 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.similarity_func import ssim
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class RandomLogit(Metric):
@@ -149,8 +154,8 @@ class RandomLogit(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -183,7 +188,7 @@ class RandomLogit(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/randomisation/random_logit.py
+++ b/quantus/metrics/randomisation/random_logit.py
@@ -15,7 +15,7 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.similarity_func import ssim
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class RandomLogit(Metric):
@@ -34,12 +34,14 @@ class RandomLogit(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Random Logit"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.RANDOMISATION
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/avg_sensitivity.py
+++ b/quantus/metrics/robustness/avg_sensitivity.py
@@ -17,7 +17,7 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.functions.similarity_func import difference
 from quantus.metrics.base_batched import BatchedPerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class AvgSensitivity(BatchedPerturbationMetric):
@@ -38,12 +38,14 @@ class AvgSensitivity(BatchedPerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Avg-Sensitivity"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/avg_sensitivity.py
+++ b/quantus/metrics/robustness/avg_sensitivity.py
@@ -37,15 +37,15 @@ class AvgSensitivity(BatchedPerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Avg-Sensitivity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.ROBUSTNESS
+    name = "Avg-Sensitivity"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/avg_sensitivity.py
+++ b/quantus/metrics/robustness/avg_sensitivity.py
@@ -41,7 +41,7 @@ class AvgSensitivity(BatchedPerturbationMetric):
     """
 
     _name = "Avg-Sensitivity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/robustness/avg_sensitivity.py
+++ b/quantus/metrics/robustness/avg_sensitivity.py
@@ -17,7 +17,12 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.functions.similarity_func import difference
 from quantus.metrics.base_batched import BatchedPerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class AvgSensitivity(BatchedPerturbationMetric):
@@ -198,8 +203,8 @@ class AvgSensitivity(BatchedPerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -232,7 +237,7 @@ class AvgSensitivity(BatchedPerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/robustness/avg_sensitivity.py
+++ b/quantus/metrics/robustness/avg_sensitivity.py
@@ -17,6 +17,7 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.functions.similarity_func import difference
 from quantus.metrics.base_batched import BatchedPerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class AvgSensitivity(BatchedPerturbationMetric):
@@ -31,7 +32,18 @@ class AvgSensitivity(BatchedPerturbationMetric):
         NeurIPS (2019): 10965-10976.
         2) Umang Bhatt et al.: "Evaluating and aggregating
         feature-based model explanations."  IJCAI (2020): 3016-3022.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Avg-Sensitivity"
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/consistency.py
+++ b/quantus/metrics/robustness/consistency.py
@@ -15,7 +15,7 @@ from quantus.functions.discretise_func import top_n_sign
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class Consistency(Metric):
@@ -38,12 +38,14 @@ class Consistency(Metric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Consistency"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/consistency.py
+++ b/quantus/metrics/robustness/consistency.py
@@ -15,7 +15,12 @@ from quantus.functions.discretise_func import top_n_sign
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class Consistency(Metric):
@@ -147,8 +152,8 @@ class Consistency(Metric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -181,7 +186,7 @@ class Consistency(Metric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/robustness/consistency.py
+++ b/quantus/metrics/robustness/consistency.py
@@ -15,12 +15,12 @@ from quantus.functions.discretise_func import top_n_sign
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.metrics.base import Metric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class Consistency(Metric):
     """
-
-    The (global) consistency metric measures the expected local consistency. Local consistency measures the probability
+    Implementation of the Consistency metric which measures the expected local consistency, i.e., the probability
     of the prediction label for a given datapoint coinciding with the prediction labels of other data points that
     the same explanation is being attributed to. For example, if the explanation of a given image is "contains zebra",
     the local consistency metric measures the probability a different image that the explanation "contains zebra" is
@@ -32,7 +32,18 @@ class Consistency(Metric):
     References:
          1) Sanjoy Dasgupta et al.: "Framework for Evaluating Faithfulness of Local
             Explanations." ICML (2022): 4794-4815.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Consistency"
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/consistency.py
+++ b/quantus/metrics/robustness/consistency.py
@@ -41,7 +41,7 @@ class Consistency(Metric):
     """
 
     _name = "Consistency"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/robustness/consistency.py
+++ b/quantus/metrics/robustness/consistency.py
@@ -37,15 +37,15 @@ class Consistency(Metric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Consistency"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.ROBUSTNESS
+    name = "Consistency"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/continuity.py
+++ b/quantus/metrics/robustness/continuity.py
@@ -17,8 +17,8 @@ from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import translation_x_direction
 from quantus.functions.similarity_func import lipschitz_constant
-from quantus.metrics.base import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.metrics.base_perturbed import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class Continuity(PerturbationMetric):
@@ -43,12 +43,14 @@ class Continuity(PerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Continuity"
     _data_applicability = {DataType.IMAGE}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/continuity.py
+++ b/quantus/metrics/robustness/continuity.py
@@ -18,6 +18,7 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import translation_x_direction
 from quantus.functions.similarity_func import lipschitz_constant
 from quantus.metrics.base import PerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class Continuity(PerturbationMetric):
@@ -37,7 +38,17 @@ class Continuity(PerturbationMetric):
         1) Grégoire Montavon et al.: "Methods for interpreting and
         understanding deep neural networks." Digital Signal Processing 73 (2018): 1-15.
 
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Continuity"
+    _data_applicability = {DataType.IMAGE}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/continuity.py
+++ b/quantus/metrics/robustness/continuity.py
@@ -42,15 +42,15 @@ class Continuity(PerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Continuity"
-    _data_applicability = {DataType.IMAGE}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.ROBUSTNESS
+    name = "Continuity"
+    data_applicability = {DataType.IMAGE}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/continuity.py
+++ b/quantus/metrics/robustness/continuity.py
@@ -18,7 +18,12 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import translation_x_direction
 from quantus.functions.similarity_func import lipschitz_constant
 from quantus.metrics.base_perturbed import PerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class Continuity(PerturbationMetric):
@@ -195,8 +200,8 @@ class Continuity(PerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -229,7 +234,7 @@ class Continuity(PerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:
@@ -348,7 +353,7 @@ class Continuity(PerturbationMetric):
             if self.abs:
                 a_perturbed = np.abs(a_perturbed)
 
-            # Store the prediction score as the last element of the sub_self.last_results dictionary.
+            # Store the prediction score as the last element of the sub_self.evaluation_scores dictionary.
             y_pred = float(model.predict(x_input)[:, y])
 
             results[self.nr_patches].append(y_pred)
@@ -452,10 +457,10 @@ class Continuity(PerturbationMetric):
         return np.mean(
             [
                 self.similarity_func(
-                    self.last_results[sample][self.nr_patches],
-                    self.last_results[sample][ix_patch],
+                    self.evaluation_scores[sample][self.nr_patches],
+                    self.evaluation_scores[sample][ix_patch],
                 )
                 for ix_patch in range(self.nr_patches)
-                for sample in self.last_results.keys()
+                for sample in self.evaluation_scores.keys()
             ]
         )

--- a/quantus/metrics/robustness/local_lipschitz_estimate.py
+++ b/quantus/metrics/robustness/local_lipschitz_estimate.py
@@ -43,7 +43,7 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
     """
 
     _name = "Local Lipschitz Estimate"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/robustness/local_lipschitz_estimate.py
+++ b/quantus/metrics/robustness/local_lipschitz_estimate.py
@@ -16,6 +16,7 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import gaussian_noise, perturb_batch
 from quantus.functions.similarity_func import lipschitz_constant, distance_euclidean
 from quantus.metrics.base_batched import BatchedPerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class LocalLipschitzEstimate(BatchedPerturbationMetric):
@@ -33,7 +34,18 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
 
         2) David Alvarez-Melis and Tommi S. Jaakkola. "Towards robust interpretability with self-explaining
         neural networks." NeurIPS (2018): 7786-7795.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Local Lipschitz Estimate"
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/local_lipschitz_estimate.py
+++ b/quantus/metrics/robustness/local_lipschitz_estimate.py
@@ -16,7 +16,12 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import gaussian_noise, perturb_batch
 from quantus.functions.similarity_func import lipschitz_constant, distance_euclidean
 from quantus.metrics.base_batched import BatchedPerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class LocalLipschitzEstimate(BatchedPerturbationMetric):
@@ -205,8 +210,8 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -239,7 +244,7 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/robustness/local_lipschitz_estimate.py
+++ b/quantus/metrics/robustness/local_lipschitz_estimate.py
@@ -16,7 +16,7 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import gaussian_noise, perturb_batch
 from quantus.functions.similarity_func import lipschitz_constant, distance_euclidean
 from quantus.metrics.base_batched import BatchedPerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class LocalLipschitzEstimate(BatchedPerturbationMetric):
@@ -40,12 +40,14 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Local Lipschitz Estimate"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/local_lipschitz_estimate.py
+++ b/quantus/metrics/robustness/local_lipschitz_estimate.py
@@ -39,15 +39,15 @@ class LocalLipschitzEstimate(BatchedPerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Local Lipschitz Estimate"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.ROBUSTNESS
+    name = "Local Lipschitz Estimate"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/max_sensitivity.py
+++ b/quantus/metrics/robustness/max_sensitivity.py
@@ -41,7 +41,7 @@ class MaxSensitivity(BatchedPerturbationMetric):
     """
 
     _name = "Max-Sensitivity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/robustness/max_sensitivity.py
+++ b/quantus/metrics/robustness/max_sensitivity.py
@@ -37,15 +37,15 @@ class MaxSensitivity(BatchedPerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Max-Sensitivity"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.ROBUSTNESS
+    name = "Max-Sensitivity"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/max_sensitivity.py
+++ b/quantus/metrics/robustness/max_sensitivity.py
@@ -17,7 +17,12 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.functions.similarity_func import difference
 from quantus.metrics.base_batched import BatchedPerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class MaxSensitivity(BatchedPerturbationMetric):
@@ -198,8 +203,8 @@ class MaxSensitivity(BatchedPerturbationMetric):
         output labels (y_batch) and a torch or tensorflow model (model).
 
         Calls general_preprocess() with all relevant arguments, calls
-        () on each instance, and saves results to last_results.
-        Calls custom_postprocess() afterwards. Finally returns last_results.
+        () on each instance, and saves results to evaluation_scores.
+        Calls custom_postprocess() afterwards. Finally returns evaluation_scores.
 
         Parameters
         ----------
@@ -232,7 +237,7 @@ class MaxSensitivity(BatchedPerturbationMetric):
 
         Returns
         -------
-        last_results: list
+        evaluation_scores: list
             a list of Any with the evaluation scores of the concerned batch.
 
         Examples:

--- a/quantus/metrics/robustness/max_sensitivity.py
+++ b/quantus/metrics/robustness/max_sensitivity.py
@@ -17,6 +17,7 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.functions.similarity_func import difference
 from quantus.metrics.base_batched import BatchedPerturbationMetric
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class MaxSensitivity(BatchedPerturbationMetric):
@@ -31,7 +32,18 @@ class MaxSensitivity(BatchedPerturbationMetric):
         NeurIPS (2019): 10965-10976.
         2) Umang Bhatt et al.: "Evaluating and aggregating
         feature-based model explanations."  IJCAI (2020): 3016-3022.
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Max-Sensitivity"
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/max_sensitivity.py
+++ b/quantus/metrics/robustness/max_sensitivity.py
@@ -17,7 +17,7 @@ from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.functions.similarity_func import difference
 from quantus.metrics.base_batched import BatchedPerturbationMetric
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class MaxSensitivity(BatchedPerturbationMetric):
@@ -38,12 +38,14 @@ class MaxSensitivity(BatchedPerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Max-Sensitivity"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @asserts.attributes_check
     def __init__(

--- a/quantus/metrics/robustness/relative_input_stability.py
+++ b/quantus/metrics/robustness/relative_input_stability.py
@@ -40,15 +40,15 @@ class RelativeInputStability(BatchedPerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Relative Output Stability"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.ROBUSTNESS
+    name = "Relative Output Stability"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @attributes_check
     def __init__(

--- a/quantus/metrics/robustness/relative_input_stability.py
+++ b/quantus/metrics/robustness/relative_input_stability.py
@@ -22,17 +22,31 @@ from quantus.helpers.asserts import attributes_check
 from quantus.functions.normalise_func import normalise_by_average_second_moment_estimate
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.helpers.utils import expand_attribution_channel
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class RelativeInputStability(BatchedPerturbationMetric):
     """
-    Relative Input Stability leverages the stability of an explanation with respect to the change in the input data
+    Relative Input Stability leverages the stability of an explanation with respect to the change in the input data.
 
-    :math:`RIS(x, x', e_x, e_x') = max \\frac{||\\frac{e_x - e_{x'}}{e_x}||_p}{max (||\\frac{x - x'}{x}||_p, \epsilon_{min})}`
+        `RIS(x, x', e_x, e_x') = max \\frac{||\\frac{e_x - e_{x'}}{e_x}||_p}
+        {max (||\\frac{x - x'}{x}||_p, \epsilon_{min})}`
 
     References:
-        1) Chirag Agarwal, et. al., 2022. "Rethinking stability for attribution based explanations.", https://arxiv.org/abs/2203.06877
+        1) Chirag Agarwal, et. al., 2022. "Rethinking stability for attribution based explanations.",
+        https://arxiv.org/abs/2203.06877
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Relative Output Stability"
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @attributes_check
     def __init__(
@@ -301,7 +315,6 @@ class RelativeInputStability(BatchedPerturbationMetric):
             The batched evaluation results.
 
         """
-
         batch_size = x_batch.shape[0]
         _explain_func = partial(
             self.explain_func, model=model.get_model(), **self.explain_func_kwargs
@@ -309,6 +322,7 @@ class RelativeInputStability(BatchedPerturbationMetric):
 
         # Prepare output array.
         ris_batch = np.zeros(shape=[self._nr_samples, x_batch.shape[0]])
+
         for index in range(self._nr_samples):
             # Perturb input.
             x_perturbed = perturb_batch(
@@ -318,15 +332,18 @@ class RelativeInputStability(BatchedPerturbationMetric):
                 arr=x_batch,
                 **self.perturb_func_kwargs,
             )
+
             # Generate explanations for perturbed input.
             a_batch_perturbed = self.generate_normalised_explanations_batch(
                 x_perturbed, y_batch, _explain_func
             )
+
             # Compute maximization's objective.
             ris = self.relative_input_stability_objective(
                 x_batch, x_perturbed, a_batch, a_batch_perturbed
             )
             ris_batch[index] = ris
+
             # We're done with this sample if `return_nan_when_prediction_changes`==False.
             if not self._return_nan_when_prediction_changes:
                 continue
@@ -346,4 +363,5 @@ class RelativeInputStability(BatchedPerturbationMetric):
         result = np.max(ris_batch, axis=0)
         if self.return_aggregate:
             result = [self.aggregate_func(result)]
+
         return result

--- a/quantus/metrics/robustness/relative_input_stability.py
+++ b/quantus/metrics/robustness/relative_input_stability.py
@@ -44,7 +44,7 @@ class RelativeInputStability(BatchedPerturbationMetric):
     """
 
     _name = "Relative Output Stability"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/robustness/relative_input_stability.py
+++ b/quantus/metrics/robustness/relative_input_stability.py
@@ -22,7 +22,7 @@ from quantus.helpers.asserts import attributes_check
 from quantus.functions.normalise_func import normalise_by_average_second_moment_estimate
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.helpers.utils import expand_attribution_channel
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class RelativeInputStability(BatchedPerturbationMetric):
@@ -41,12 +41,14 @@ class RelativeInputStability(BatchedPerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Relative Output Stability"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @attributes_check
     def __init__(

--- a/quantus/metrics/robustness/relative_input_stability.py
+++ b/quantus/metrics/robustness/relative_input_stability.py
@@ -22,7 +22,12 @@ from quantus.helpers.asserts import attributes_check
 from quantus.functions.normalise_func import normalise_by_average_second_moment_estimate
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.helpers.utils import expand_attribution_channel
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class RelativeInputStability(BatchedPerturbationMetric):

--- a/quantus/metrics/robustness/relative_output_stability.py
+++ b/quantus/metrics/robustness/relative_output_stability.py
@@ -41,15 +41,15 @@ class RelativeOutputStability(BatchedPerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Relative Output Stability"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.ROBUSTNESS
+    name = "Relative Output Stability"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @attributes_check
     def __init__(

--- a/quantus/metrics/robustness/relative_output_stability.py
+++ b/quantus/metrics/robustness/relative_output_stability.py
@@ -21,21 +21,33 @@ from quantus.helpers.asserts import attributes_check
 from quantus.functions.normalise_func import normalise_by_average_second_moment_estimate
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.helpers.utils import expand_attribution_channel
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class RelativeOutputStability(BatchedPerturbationMetric):
     """
-    Relative Output Stability leverages the stability of an explanation with respect
-    to the change in the output logits
+    Relative Output Stability leverages the stability of an explanation with respect to the change in the output logits.
 
-    :math:`ROS(x, x', ex, ex') = max \\frac{||\\frac{e_x - e_x'}{e_x}||_p}{max (||h(x) - h(x')||_p, \epsilon_{min})}`,
+        `ROS(x, x', ex, ex') = max \\frac{||\\frac{e_x - e_x'}{e_x}||_p}
+        {max (||h(x) - h(x')||_p, \epsilon_{min})}`,
 
-    where `h(x)` and `h(x')` are the output logits for `x` and `x'` respectively
-
+    where `h(x)` and `h(x')` are the output logits for `x` and `x'` respectively.
 
     References:
-        1) Chirag Agarwal, et. al., 2022. "Rethinking stability for attribution based explanations.", https://arxiv.org/pdf/2203.06877.pdf
+        1) Chirag Agarwal, et. al., 2022. "Rethinking stability for attribution based explanations.",
+        https://arxiv.org/pdf/2203.06877.pdf
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Relative Output Stability"
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @attributes_check
     def __init__(
@@ -315,10 +327,12 @@ class RelativeOutputStability(BatchedPerturbationMetric):
         )
         # Execute forward pass on provided inputs.
         logits = model.predict(x_batch)
+
         # Prepare output array.
         ros_batch = np.zeros(shape=[self._nr_samples, x_batch.shape[0]])
 
         for index in range(self._nr_samples):
+
             # Perturb input.
             x_perturbed = perturb_batch(
                 perturb_func=self.perturb_func,
@@ -327,10 +341,12 @@ class RelativeOutputStability(BatchedPerturbationMetric):
                 arr=x_batch,
                 **self.perturb_func_kwargs,
             )
+
             # Generate explanations for perturbed input.
             a_batch_perturbed = self.generate_normalised_explanations_batch(
                 x_perturbed, y_batch, _explain_func
             )
+
             # Execute forward pass on perturbed inputs.
             logits_perturbed = model.predict(x_perturbed)
             # Compute maximization's objective.
@@ -338,6 +354,7 @@ class RelativeOutputStability(BatchedPerturbationMetric):
                 logits, logits_perturbed, a_batch, a_batch_perturbed
             )
             ros_batch[index] = ros
+
             # We're done with this sample if `return_nan_when_prediction_changes`==False.
             if not self._return_nan_when_prediction_changes:
                 continue
@@ -351,10 +368,12 @@ class RelativeOutputStability(BatchedPerturbationMetric):
 
             if len(changed_prediction_indices) == 0:
                 continue
+
             ros_batch[index, changed_prediction_indices] = np.nan
 
         # Compute ROS.
         result = np.max(ros_batch, axis=0)
         if self.return_aggregate:
             result = [self.aggregate_func(result)]
+
         return result

--- a/quantus/metrics/robustness/relative_output_stability.py
+++ b/quantus/metrics/robustness/relative_output_stability.py
@@ -45,7 +45,7 @@ class RelativeOutputStability(BatchedPerturbationMetric):
     """
 
     _name = "Relative Output Stability"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/robustness/relative_output_stability.py
+++ b/quantus/metrics/robustness/relative_output_stability.py
@@ -21,7 +21,12 @@ from quantus.helpers.asserts import attributes_check
 from quantus.functions.normalise_func import normalise_by_average_second_moment_estimate
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.helpers.utils import expand_attribution_channel
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class RelativeOutputStability(BatchedPerturbationMetric):

--- a/quantus/metrics/robustness/relative_output_stability.py
+++ b/quantus/metrics/robustness/relative_output_stability.py
@@ -21,7 +21,7 @@ from quantus.helpers.asserts import attributes_check
 from quantus.functions.normalise_func import normalise_by_average_second_moment_estimate
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.helpers.utils import expand_attribution_channel
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class RelativeOutputStability(BatchedPerturbationMetric):
@@ -42,12 +42,14 @@ class RelativeOutputStability(BatchedPerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Relative Output Stability"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @attributes_check
     def __init__(

--- a/quantus/metrics/robustness/relative_representation_stability.py
+++ b/quantus/metrics/robustness/relative_representation_stability.py
@@ -43,15 +43,15 @@ class RelativeRepresentationStability(BatchedPerturbationMetric):
         -  _name: The name of the metric.
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
-        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
-        - _evaluation_category: What property/ explanation quality that this metric measures.
+        - score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - evaluation_category: What property/ explanation quality that this metric measures.
     """
 
-    _name = "Relative Representation Stability"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
-    _model_applicability = {ModelType.TORCH, ModelType.TF}
-    _score_direction = ScoreDirection.LOWER
-    _evaluation_category = EvaluationCategory.ROBUSTNESS
+    name = "Relative Representation Stability"
+    data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
+    model_applicability = {ModelType.TORCH, ModelType.TF}
+    score_direction = ScoreDirection.LOWER
+    evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @attributes_check
     def __init__(

--- a/quantus/metrics/robustness/relative_representation_stability.py
+++ b/quantus/metrics/robustness/relative_representation_stability.py
@@ -22,7 +22,12 @@ from quantus.helpers.asserts import attributes_check
 from quantus.functions.normalise_func import normalise_by_average_second_moment_estimate
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.helpers.utils import expand_attribution_channel
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
+from quantus.helpers.enums import (
+    ModelType,
+    DataType,
+    ScoreDirection,
+    EvaluationCategory,
+)
 
 
 class RelativeRepresentationStability(BatchedPerturbationMetric):

--- a/quantus/metrics/robustness/relative_representation_stability.py
+++ b/quantus/metrics/robustness/relative_representation_stability.py
@@ -47,7 +47,7 @@ class RelativeRepresentationStability(BatchedPerturbationMetric):
     """
 
     _name = "Relative Representation Stability"
-    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
 

--- a/quantus/metrics/robustness/relative_representation_stability.py
+++ b/quantus/metrics/robustness/relative_representation_stability.py
@@ -22,7 +22,7 @@ from quantus.helpers.asserts import attributes_check
 from quantus.functions.normalise_func import normalise_by_average_second_moment_estimate
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.helpers.utils import expand_attribution_channel
-from quantus.helpers.enums import ModelType, DataType, ScoreDirection
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection, EvaluationCategory
 
 
 class RelativeRepresentationStability(BatchedPerturbationMetric):
@@ -44,12 +44,14 @@ class RelativeRepresentationStability(BatchedPerturbationMetric):
         - _data_applicability: The data types that the metric implementation currently supports.
         - _models: The model types that this metric can work with.
         - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
+        - _evaluation_category: What property/ explanation quality that this metric measures.
     """
 
     _name = "Relative Representation Stability"
     _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABULAR}
     _model_applicability = {ModelType.TORCH, ModelType.TF}
     _score_direction = ScoreDirection.LOWER
+    _evaluation_category = EvaluationCategory.ROBUSTNESS
 
     @attributes_check
     def __init__(

--- a/quantus/metrics/robustness/relative_representation_stability.py
+++ b/quantus/metrics/robustness/relative_representation_stability.py
@@ -22,20 +22,34 @@ from quantus.helpers.asserts import attributes_check
 from quantus.functions.normalise_func import normalise_by_average_second_moment_estimate
 from quantus.functions.perturb_func import uniform_noise, perturb_batch
 from quantus.helpers.utils import expand_attribution_channel
+from quantus.helpers.enums import ModelType, DataType, ScoreDirection
 
 
 class RelativeRepresentationStability(BatchedPerturbationMetric):
     """
-    Relative Output Stability leverages the stability of an explanation with respect
-    to the change in the output logits
+    Relative Representation Stability leverages the stability of an explanation with respect
+    to the change in the output logits.
 
-    :math:`RRS(x, x', ex, ex') = max \\frac{||\\frac{e_x - e_{x'}}{e_x}||_p}{max (||\\frac{L_x - L_{x'}}{L_x}||_p, \epsilon_{min})},`
+        `RRS(x, x', ex, ex') = max \\frac{||\\frac{e_x - e_{x'}}{e_x}||_p}
+        {max (||\\frac{L_x - L_{x'}}{L_x}||_p, \epsilon_{min})},`
 
     where `L(·)` denotes the internal model representation, e.g., output embeddings of hidden layers.
 
     References:
-        1) Chirag Agarwal, et. al., 2022. "Rethinking stability for attribution based explanations.", https://arxiv.org/pdf/2203.06877.pdf
+        1) Chirag Agarwal, et. al., 2022. "Rethinking stability for attribution based explanations.",
+        https://arxiv.org/pdf/2203.06877.pdf
+
+    Attributes:
+        -  _name: The name of the metric.
+        - _data_applicability: The data types that the metric implementation currently supports.
+        - _models: The model types that this metric can work with.
+        - _score_direction: How to interpret the scores, whether higher/ lower values are considered better.
     """
+
+    _name = "Relative Representation Stability"
+    _data_applicability = {DataType.IMAGE, DataType.TIMESERIES, DataType.TABLUAR}
+    _model_applicability = {ModelType.TORCH, ModelType.TF}
+    _score_direction = ScoreDirection.LOWER
 
     @attributes_check
     def __init__(
@@ -324,10 +338,12 @@ class RelativeRepresentationStability(BatchedPerturbationMetric):
         _explain_func = partial(
             self.explain_func, model=model.get_model(), **self.explain_func_kwargs
         )
+
         # Retrieve internal representation for provided inputs.
         internal_representations = model.get_hidden_representations(
             x_batch, self._layer_names, self._layer_indices
         )
+
         # Prepare output array.
         rrs_batch = np.zeros(shape=[self._nr_samples, x_batch.shape[0]])
 
@@ -340,14 +356,17 @@ class RelativeRepresentationStability(BatchedPerturbationMetric):
                 arr=x_batch,
                 **self.perturb_func_kwargs,
             )
+
             # Generate explanations for perturbed input.
             a_batch_perturbed = self.generate_normalised_explanations_batch(
                 x_perturbed, y_batch, _explain_func
             )
+
             # Retrieve internal representation for perturbed inputs.
             internal_representations_perturbed = model.get_hidden_representations(
                 x_perturbed, self._layer_names, self._layer_indices
             )
+
             # Compute maximization's objective.
             rrs = self.relative_representation_stability_objective(
                 internal_representations,
@@ -356,6 +375,7 @@ class RelativeRepresentationStability(BatchedPerturbationMetric):
                 a_batch_perturbed,
             )
             rrs_batch[index] = rrs
+
             # We're done with this sample if `return_nan_when_prediction_changes`==False.
             if not self._return_nan_when_prediction_changes:
                 continue
@@ -375,4 +395,5 @@ class RelativeRepresentationStability(BatchedPerturbationMetric):
         result = np.max(rrs_batch, axis=0)
         if self.return_aggregate:
             result = [self.aggregate_func(result)]
+
         return result


### PR DESCRIPTION
### Addressed issues:
- https://github.com/understandable-machine-intelligence-lab/Quantus/issues/280
- https://github.com/understandable-machine-intelligence-lab/Quantus/issues/202
- Renaming from `last_results` to `evaluation_scores` and `all_results` to  `all_evaluation_scores`

### Minimum acceptance criteria
- Specify what is necessary for the PR to be merged with the main branch.
- @mentions of the person that is apt to review these changes e.g., @annahedstroem
