### PR TITLE
Make randomisation metrics batched

### DIFF
--- a/quantus/helpers/utils.py
+++ b/quantus/helpers/utils.py
@@ -995,3 +995,23 @@ def calculate_auc(values: np.array, dx: int = 1):
         Definite integral of values.
     """
     return np.trapz(np.array(values), dx=dx)
+
+
+def flatten_over_batch(arr: np.ndarray) -> np.ndarray:
+    """
+    Flatten each element in batch. Accepts array with rank 3 and higher.
+
+    Examples:
+        >>> x = np.random.default_rng().uniform(0, 1, [8, 24, 24, 3])
+        >>> flatten_over_batch(x).shape
+        >>> (8, 1728)
+    """
+
+    # Is identical to https://www.tensorflow.org/api_docs/python/tf/rank, just it is missing in numpy API
+    rank = len(np.shape(arr))
+
+    if rank < 3:
+        return arr
+
+    batch_size = len(arr)
+    return np.reshape(arr, (batch_size, -1))

--- a/quantus/metrics/base_batched.py
+++ b/quantus/metrics/base_batched.py
@@ -6,9 +6,7 @@
 # You should have received a copy of the GNU Lesser General Public License along with Quantus. If not, see <https://www.gnu.org/licenses/>.
 # Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
 
-import inspect
 import math
-import re
 from abc import abstractmethod
 from typing import Any, Callable, Dict, Optional, Sequence, Union
 
@@ -16,8 +14,7 @@ import numpy as np
 from tqdm.auto import tqdm
 
 from quantus.metrics.base import Metric
-from quantus.helpers import asserts
-from quantus.helpers import warn
+from quantus.helpers import asserts, warn, utils
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.helpers.enums import (
     ModelType,
@@ -431,6 +428,8 @@ class BatchedMetric(Metric):
             targets=y_batch,
             **self.explain_func_kwargs
         )
+        a_batch = utils.expand_attribution_channel(a_batch, x_batch)
+        asserts.assert_attributions(x_batch=x_batch, a_batch=a_batch)
 
         # Normalise and take absolute values of the attributions, if configured during metric instantiation.
         if self.normalise:

--- a/quantus/metrics/randomisation/model_parameter_randomisation.py
+++ b/quantus/metrics/randomisation/model_parameter_randomisation.py
@@ -7,32 +7,28 @@
 # Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
 
 import collections
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Union,
-    Collection,
-    no_type_check,
-    final,
-)
+import sys
+from typing import Any, Callable, Collection, Dict, List, Optional, Union, no_type_check
 
 import numpy as np
 from tqdm.auto import tqdm
 
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.similarity_func import correlation_spearman
-from quantus.helpers import asserts, warn, utils
+from quantus.helpers import asserts, utils, warn
 from quantus.helpers.enums import (
-    ModelType,
     DataType,
-    ScoreDirection,
     EvaluationCategory,
+    ModelType,
+    ScoreDirection,
 )
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.metrics.base_batched import BatchedMetric
+
+if sys.version_info > (3, 7):
+    from typing import final
+else:
+    from typing_extensions import final
 
 
 @final

--- a/quantus/metrics/randomisation/model_parameter_randomisation.py
+++ b/quantus/metrics/randomisation/model_parameter_randomisation.py
@@ -16,7 +16,7 @@ from typing import (
     Union,
     Collection,
     no_type_check,
-    final
+    final,
 )
 
 import numpy as np

--- a/quantus/metrics/randomisation/model_parameter_randomisation.py
+++ b/quantus/metrics/randomisation/model_parameter_randomisation.py
@@ -25,7 +25,7 @@ from quantus.helpers.enums import (
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.metrics.base_batched import BatchedMetric
 
-if sys.version_info > (3, 7):
+if sys.version_info >= (3, 8):
     from typing import final
 else:
     from typing_extensions import final

--- a/quantus/metrics/randomisation/random_logit.py
+++ b/quantus/metrics/randomisation/random_logit.py
@@ -6,20 +6,27 @@
 # You should have received a copy of the GNU Lesser General Public License along with Quantus. If not, see <https://www.gnu.org/licenses/>.
 # Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
 
-from typing import Any, Callable, Dict, List, Optional, final
+import sys
+from typing import Any, Callable, Dict, List, Optional
+
 import numpy as np
 
-from quantus.helpers import asserts, warn, utils
-from quantus.helpers.model.model_interface import ModelInterface
 from quantus.functions.normalise_func import normalise_by_max
 from quantus.functions.similarity_func import ssim
-from quantus.metrics.base_batched import BatchedMetric
+from quantus.helpers import asserts, utils, warn
 from quantus.helpers.enums import (
-    ModelType,
     DataType,
-    ScoreDirection,
     EvaluationCategory,
+    ModelType,
+    ScoreDirection,
 )
+from quantus.helpers.model.model_interface import ModelInterface
+from quantus.metrics.base_batched import BatchedMetric
+
+if sys.version_info > (3, 7):
+    from typing import final
+else:
+    from typing_extensions import final
 
 
 @final

--- a/quantus/metrics/randomisation/random_logit.py
+++ b/quantus/metrics/randomisation/random_logit.py
@@ -23,7 +23,7 @@ from quantus.helpers.enums import (
 from quantus.helpers.model.model_interface import ModelInterface
 from quantus.metrics.base_batched import BatchedMetric
 
-if sys.version_info > (3, 7):
+if sys.version_info >= (3, 8):
     from typing import final
 else:
     from typing_extensions import final

--- a/quantus/metrics/randomisation/random_logit.py
+++ b/quantus/metrics/randomisation/random_logit.py
@@ -6,7 +6,7 @@
 # You should have received a copy of the GNU Lesser General Public License along with Quantus. If not, see <https://www.gnu.org/licenses/>.
 # Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
 
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, final
 import numpy as np
 
 from quantus.helpers import asserts, warn, utils
@@ -22,6 +22,7 @@ from quantus.helpers.enums import (
 )
 
 
+@final
 class RandomLogit(BatchedMetric):
     """
     Implementation of the Random Logit Metric by Sixt et al., 2020.

--- a/quantus/metrics/randomisation/random_logit.py
+++ b/quantus/metrics/randomisation/random_logit.py
@@ -8,7 +8,6 @@
 
 from typing import Any, Callable, Dict, List, Optional
 import numpy as np
-import logging
 
 from quantus.helpers import asserts, warn, utils
 from quantus.helpers.model.model_interface import ModelInterface
@@ -21,8 +20,6 @@ from quantus.helpers.enums import (
     ScoreDirection,
     EvaluationCategory,
 )
-
-log = logging.getLogger("quantus")
 
 
 class RandomLogit(BatchedMetric):


### PR DESCRIPTION
### Description
- While working ob batched explanation preprocessing (to avoid OOM), I discovered, that instance-wise metrics would re
- Moreover, most of the instance wise metrics can easily become batched, and in general, we can get rid of batch vs instance wise differention. I think this will make the codebase more uniform, maintainable and easy to read. Additionally, we could gain a bit of performance improvement
- This is a first step towards making (mostly) all metrics batched.

### Implemented changes
  - [x] Make `ModelParametersRandomisation` batched
  - [x] Make `RandomLogit` batched

### Minimum acceptance criteria
- API contract is unchanged
- metrics still return the same scores.
