### PR TITLE
dynamic version fix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,4 +34,8 @@ jobs:
       - name: Test with PyTest
         run: tox run
       - name: Test building package
-        run: tox run -e build
+        run: |
+          tox run -e build
+          pip install dist/*.whl
+          cd /tmp
+          python3 -c "import quantus;quantus.__version__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ name = "quantus"
 
 # Versions should comply with PEP 440:
 # https://www.python.org/dev/peps/pep-0440/
-version = "0.4.2"
 description = "A metrics toolkit to evaluate neural network explanations."
 readme = "README.md"
 requires-python = ">=3.7"
@@ -35,8 +34,9 @@ dependencies = [
     "scipy>=1.7.3",
     "tqdm>=4.62.3",
     "matplotlib>=3.3.4",
-    "toml>=0.6.0"
 ]
+
+dynamic = ["version"]
 
 [project.urls]
 "Documentation" = "https://quantus.readthedocs.io/en/latest/"

--- a/quantus/__init__.py
+++ b/quantus/__init__.py
@@ -5,9 +5,7 @@
 # Quantus project URL: <https://github.com/understandable-machine-intelligence-lab/Quantus>.
 
 # Set the correct version.
-import toml
-package = toml.load("pyproject.toml")
-__version__ = package["project"]["version"]
+__version__ = "0.4.2"
 
 # Expose quantus.evaluate to the user.
 from quantus.evaluation import evaluate


### PR DESCRIPTION
### Description
- Fix for the installation problem https://github.com/understandable-machine-intelligence-lab/Quantus/issues/292, which was introduced in https://github.com/understandable-machine-intelligence-lab/Quantus/pull/291

- [x] import issue resolved
- [x] added step to `python-package` action, which check if the library is importable

To sum up, the `__version__` must be defined in top-level `__init__.py` as a string literal, 
then it will be dynamically fetched by `flit` during packaging stage.
