### PR TITLE
* allow custom model

### DIFF
--- a/quantus/helpers/utils.py
+++ b/quantus/helpers/utils.py
@@ -382,6 +382,8 @@ def get_wrapped_model(
     model: ModelInterface
         A wrapped ModelInterface model.
     """
+    if isinstance(model, ModelInterface):
+        return model
     if util.find_spec("tensorflow"):
         if isinstance(model, tf.keras.Model):
             return TensorFlowModel(


### PR DESCRIPTION
### Description
- Right now, user can only use `TensorFlowModel` or `PyTorchModel` from `quantus`
- If user wants to evaluate, e.g, baseline (sklearn) model, there is no way

### Implemented changes
  - [x] Allow custom implementers of `ModelInterface`

