### PR TITLE
Update attribution_localisation.py

### DIFF
--- a/quantus/metrics/localisation/attribution_localisation.py
+++ b/quantus/metrics/localisation/attribution_localisation.py
@@ -57,6 +57,7 @@ class AttributionLocalisation(Metric[List[float]]):
         self,
         weighted: bool = False,
         max_size: float = 1.0,
+        positive_attributions: bool = False,
         abs: bool = True,
         normalise: bool = True,
         normalise_func: Optional[Callable] = None,
@@ -76,6 +77,9 @@ class AttributionLocalisation(Metric[List[float]]):
             default=False.
         max_size: float
             The maximum ratio for  the size of the bounding box to image, default=1.0.
+        positive_attributions: boolean
+            Indicates whether only positive attributions should be used, i.e., clipping,
+            default=False.
         abs: boolean
             Indicates whether absolute operation is applied on the attribution, default=True.
         normalise: boolean
@@ -118,6 +122,7 @@ class AttributionLocalisation(Metric[List[float]]):
         # Save metric-specific attributes.
         self.weighted = weighted
         self.max_size = max_size
+        self.positive_attributions = positive_attributions
         if not self.disable_warnings:
             warn.warn_parameterisation(
                 metric_name=self.__class__.__name__,
@@ -270,6 +275,8 @@ class AttributionLocalisation(Metric[List[float]]):
 
         # Prepare shapes.
         a = a.flatten()
+        if self.positive_attributions:
+            a = np.clip(a, 0, None)
         s = s.flatten().astype(bool)
 
         # Compute ratio.


### PR DESCRIPTION
### Problem
from user:
> "The thing is that I noticed strange behaviors when testing with AttributionLocalization. When I used all-positive attributions, our method worked great, but when I used N(0,1) attributions, it didn't work at all. I ran through Quantus code and read the Attribution Localization paper and I think I've identified the problem, but I'm confused as to how to proceed. It turns out, AttributionLocalisation in Quantus by default takes the absolute value of all attributions. This means that the very negative (low impact in the output) attributions become very positive (high impact), which completely messes the ranking. I switch abs=False, but now AttributionLocalisation complains because in some cases the total attribution inside the mask is larger than the total attribution of the whole image (and it returns NaN)"

### Description
- One code line change plus docstrings


### Minimum acceptance criteria
- Specify what is necessary for the PR to be merged with the main branch.
- @mentions of the person that is apt to review these changes e.g., @annahedstroem
