### PR TITLE
Integrate AutoModelForSequenceClassification through PytorchModel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,6 @@ dependencies = [
     "tqdm>=4.62.3",
     "matplotlib>=3.3.4",
     "typing_extensions; python_version <= '3.8'",
-    "transformers<=4.30.2; python_version == '3.7'",
-    "transformers>=4.38.2; python_version > '3.7'",
 ]
 
 dynamic = ["version"]
@@ -86,6 +84,8 @@ torch = [
     "torchvision>=0.15.1; sys_platform != 'linux' and python_version > '3.7'",
     "torchvision>=0.14.0, <0.15.1; sys_platform == 'linux' and python_version > '3.7' and python_version <= '3.10'",
     "torchvision>=0.15.1; sys_platform == 'linux' and python_version >= '3.11'"
+    "transformers<=4.30.2; python_version == '3.7'",
+    "transformers>=4.38.2; python_version > '3.7'",
 ]
 tensorflow = [
     "tensorflow>=2.5.0; python_version == '3.7'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ tests = [
     "torchvision<=0.12.0; python_version == '3.7'",
     "torchvision>=0.15.1; sys_platform != 'linux' and python_version > '3.7'",
     "torchvision>=0.14.0, <0.15.1; sys_platform == 'linux' and python_version > '3.7' and python_version <= '3.10'",
-    "torchvision>=0.15.1; sys_platform == 'linux' and python_version >= '3.11'"
+    "torchvision>=0.15.1; sys_platform == 'linux' and python_version >= '3.11'",
     "transformers<=4.30.2; python_version == '3.7'",
     "transformers>=4.38.2; python_version > '3.7'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dynamic = ["version"]
 #
 [project.optional-dependencies]
 tests = [
-    "cachetools>=5.3.3",
     "captum>=0.6.0",
     "coverage>=7.2.3",
     "flake8<=4.0.1; python_version == '3.7'",
@@ -77,8 +76,6 @@ tests = [
     "torchvision>=0.15.1; sys_platform != 'linux' and python_version > '3.7'",
     "torchvision>=0.14.0, <0.15.1; sys_platform == 'linux' and python_version > '3.7' and python_version <= '3.10'",
     "torchvision>=0.15.1; sys_platform == 'linux' and python_version >= '3.11'",
-    "transformers<=4.30.2; python_version == '3.7'",
-    "transformers>=4.38.2; python_version > '3.7'",
 ]
 torch = [
     "torch<=1.11.0; python_version == '3.7'",
@@ -109,8 +106,13 @@ zennit = [
     "quantus[torch]",
     "zennit>=0.5.1"
 ]
+transformers = [
+    "quantus[torch, tensorflow]",
+    "transformers<=4.30.2; python_version == '3.7'",
+    "transformers>=4.38.2; python_version > '3.7'",
+]
 full = [
-    "quantus[captum,tf_explain,zennit]"
+    "quantus[captum,tf_explain,zennit, transformers]"
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,9 @@ dependencies = [
     "scipy>=1.7.3",
     "tqdm>=4.62.3",
     "matplotlib>=3.3.4",
-    "typing_extensions; python_version <= '3.8'"
+    "typing_extensions; python_version <= '3.8'",
+    "transformers<=4.30.2; python_version == '3.7'",
+    "transformers>=4.38.2; python_version > '3.7'",
 ]
 
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ tests = [
     "torchvision>=0.15.1; sys_platform != 'linux' and python_version > '3.7'",
     "torchvision>=0.14.0, <0.15.1; sys_platform == 'linux' and python_version > '3.7' and python_version <= '3.10'",
     "torchvision>=0.15.1; sys_platform == 'linux' and python_version >= '3.11'"
+    "transformers<=4.30.2; python_version == '3.7'",
+    "transformers>=4.38.2; python_version > '3.7'",
 ]
 torch = [
     "torch<=1.11.0; python_version == '3.7'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,31 +52,6 @@ dynamic = ["version"]
 #   $ pip install quantus[tensorflow]
 #
 [project.optional-dependencies]
-tests = [
-    "captum>=0.6.0",
-    "coverage>=7.2.3",
-    "flake8<=4.0.1; python_version == '3.7'",
-    "flake8>=6.0.0; python_version > '3.7'",
-    "pytest<=7.4.4",
-    "pytest-cov>=4.0.0",
-    "pytest-lazy-fixture>=0.6.3",
-    "pytest-mock==3.10.0",
-    "pytest_xdist",
-    "tf-explain>=0.3.1",
-    "keras<3",
-    "zennit>=0.4.5; python_version >= '3.7'",
-    "tensorflow>=2.5.0; python_version == '3.7'",
-    "tensorflow>=2.12.0; sys_platform != 'darwin' and python_version > '3.7'",
-    "tensorflow_macos>=2.9.0; sys_platform == 'darwin' and python_version > '3.7'",
-    "torch<=1.9.0; python_version == '3.7'",
-    "torch>=1.13.1; sys_platform != 'linux' and python_version > '3.7'",
-    "torch>=1.13.1, <2.0.0; sys_platform == 'linux' and python_version > '3.7' and python_version <= '3.10'",
-    "torch>=2.0.0; sys_platform == 'linux' and python_version >= '3.11'",
-    "torchvision<=0.12.0; python_version == '3.7'",
-    "torchvision>=0.15.1; sys_platform != 'linux' and python_version > '3.7'",
-    "torchvision>=0.14.0, <0.15.1; sys_platform == 'linux' and python_version > '3.7' and python_version <= '3.10'",
-    "torchvision>=0.15.1; sys_platform == 'linux' and python_version >= '3.11'",
-]
 torch = [
     "torch<=1.11.0; python_version == '3.7'",
     "torch>=1.13.1; sys_platform != 'linux' and python_version > '3.7'",
@@ -110,6 +85,32 @@ transformers = [
     "quantus[torch, tensorflow]",
     "transformers<=4.30.2; python_version == '3.7'",
     "transformers>=4.38.2; python_version > '3.7'",
+]
+tests = [
+    "captum>=0.6.0",
+    "coverage>=7.2.3",
+    "flake8<=4.0.1; python_version == '3.7'",
+    "flake8>=6.0.0; python_version > '3.7'",
+    "pytest<=7.4.4",
+    "pytest-cov>=4.0.0",
+    "pytest-lazy-fixture>=0.6.3",
+    "pytest-mock==3.10.0",
+    "pytest_xdist",
+    "tf-explain>=0.3.1",
+    "keras<3",
+    "zennit>=0.4.5; python_version >= '3.7'",
+    "tensorflow>=2.5.0; python_version == '3.7'",
+    "tensorflow>=2.12.0; sys_platform != 'darwin' and python_version > '3.7'",
+    "tensorflow_macos>=2.9.0; sys_platform == 'darwin' and python_version > '3.7'",
+    "torch<=1.9.0; python_version == '3.7'",
+    "torch>=1.13.1; sys_platform != 'linux' and python_version > '3.7'",
+    "torch>=1.13.1, <2.0.0; sys_platform == 'linux' and python_version > '3.7' and python_version <= '3.10'",
+    "torch>=2.0.0; sys_platform == 'linux' and python_version >= '3.11'",
+    "torchvision<=0.12.0; python_version == '3.7'",
+    "torchvision>=0.15.1; sys_platform != 'linux' and python_version > '3.7'",
+    "torchvision>=0.14.0, <0.15.1; sys_platform == 'linux' and python_version > '3.7' and python_version <= '3.10'",
+    "torchvision>=0.15.1; sys_platform == 'linux' and python_version >= '3.11'",
+    "quantus[captum,tf_explain,zennit, transformers]"
 ]
 full = [
     "quantus[captum,tf_explain,zennit, transformers]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dynamic = ["version"]
 #
 [project.optional-dependencies]
 tests = [
+    "cachetools>=5.3.3",
     "captum>=0.6.0",
     "coverage>=7.2.3",
     "flake8<=4.0.1; python_version == '3.7'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ torch = [
     "torchvision<=0.12.0; python_version == '3.7'",
     "torchvision>=0.15.1; sys_platform != 'linux' and python_version > '3.7'",
     "torchvision>=0.14.0, <0.15.1; sys_platform == 'linux' and python_version > '3.7' and python_version <= '3.10'",
-    "torchvision>=0.15.1; sys_platform == 'linux' and python_version >= '3.11'"
+    "torchvision>=0.15.1; sys_platform == 'linux' and python_version >= '3.11'",
     "transformers<=4.30.2; python_version == '3.7'",
     "transformers>=4.38.2; python_version > '3.7'",
 ]

--- a/quantus/helpers/model/pytorch_model.py
+++ b/quantus/helpers/model/pytorch_model.py
@@ -101,9 +101,19 @@ class PyTorchModel(ModelInterface[nn.Module]):
     def _obtain_predictions(self, x, model_predict_kwargs):
         pred = None
         if isinstance(self.model, PreTrainedModel):
-            if not isinstance(x, BatchEncoding):
+            # BatchEncoding is the default output from Tokenizers which contains
+            # necessary keys such as `input_ids` and `attention_mask`.
+            # It is also possible to pass a Dict with those keys.
+            if not (
+                isinstance(x, BatchEncoding)
+                or (
+                    isinstance(x, dict)
+                    and ("input_ids" in x.keys() and "attention_mask" in x.keys())
+                )
+            ):
                 raise ValueError(
-                    "When using HuggingFace pretrained models, please use Tokenizers output for `x`"
+                    "When using HuggingFace pretrained models, please use Tokenizers output for `x` "
+                    "or make sure you're passing a dict with input_ids and attention_mask as keys"
                 )
             pred = self.model(**x, **model_predict_kwargs).logits
         elif isinstance(self.model, nn.Module):

--- a/quantus/helpers/model/pytorch_model.py
+++ b/quantus/helpers/model/pytorch_model.py
@@ -115,7 +115,10 @@ class PyTorchModel(ModelInterface[nn.Module]):
                     "When using HuggingFace pretrained models, please use Tokenizers output for `x` "
                     "or make sure you're passing a dict with input_ids and attention_mask as keys"
                 )
+            pred_model = self.get_softmax_arg_model()
             pred = self.model(**x, **model_predict_kwargs).logits
+            if self.softmax:
+                return torch.softmax(pred, dim=-1)
         elif isinstance(self.model, nn.Module):
             pred_model = self.get_softmax_arg_model()
             pred = pred_model(torch.Tensor(x).to(self.device), **model_predict_kwargs)

--- a/quantus/helpers/model/pytorch_model.py
+++ b/quantus/helpers/model/pytorch_model.py
@@ -451,7 +451,7 @@ class PyTorchModel(ModelInterface[nn.Module]):
         hidden_layers = list(  # type: ignore
             filter(
                 lambda layer: not isinstance(
-                    layer_names[1], (self.model.__class__, torch.nn.Sequential)
+                    layer[1], (self.model.__class__, torch.nn.Sequential)
                 ),
                 all_layers,
             )

--- a/quantus/helpers/model/pytorch_model.py
+++ b/quantus/helpers/model/pytorch_model.py
@@ -280,9 +280,9 @@ class PyTorchModel(ModelInterface[nn.Module]):
         random_layer_model = deepcopy(self.model)
 
         modules = [
-            l
-            for l in random_layer_model.named_modules()
-            if (hasattr(l[1], "reset_parameters"))
+            layer
+            for layer in random_layer_model.named_modules()
+            if (hasattr(layer[1], "reset_parameters"))
         ]
 
         if order == "top_down":
@@ -365,7 +365,7 @@ class PyTorchModel(ModelInterface[nn.Module]):
         with torch.no_grad():
             new_model = deepcopy(self.model)
 
-            modules = [l for l in new_model.named_modules()]
+            modules = [layer for layer in new_model.named_modules()]
             module = modules[1]
 
             delta = torch.zeros(size=shape).fill_(input_shift)
@@ -392,8 +392,8 @@ class PyTorchModel(ModelInterface[nn.Module]):
         """
         Compute the model's internal representation of input x.
         In practice, this means, executing a forward pass and then, capturing the output of layers (of interest).
-        As the exact definition of "internal model representation" is left out in the original paper (see: https://arxiv.org/pdf/2203.06877.pdf),
-        we make the implementation flexible.
+        As the exact definition of "internal model representation" is left out in the original paper
+        (see: https://arxiv.org/pdf/2203.06877.pdf), we make the implementation flexible.
         It is up to the user whether all layers are used, or specific ones should be selected.
         The user can therefore select a layer by providing 'layer_names' (exclusive) or 'layer_indices'.
 
@@ -437,8 +437,8 @@ class PyTorchModel(ModelInterface[nn.Module]):
         # skip modules defined by subclassing API.
         hidden_layers = list(  # type: ignore
             filter(
-                lambda l: not isinstance(
-                    l[1], (self.model.__class__, torch.nn.Sequential)
+                lambda layer: not isinstance(
+                    layer_names[1], (self.model.__class__, torch.nn.Sequential)
                 ),
                 all_layers,
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,26 +1,26 @@
-import pytest
-import pickle
-import torch
-import numpy as np
-from keras.datasets import cifar10
-import pandas as pd
-from sklearn.model_selection import train_test_split
 import os
+import pickle
 
-from quantus.helpers.model.models import (
-    LeNet,
-    LeNetTF,
-    CifarCNNModel,
-    ConvNet1D,
-    ConvNet1DTF,
-    TitanicSimpleTFModel,
-    TitanicSimpleTorchModel,
-)
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+from keras.datasets import cifar10
+from quantus.helpers.model.models import (CifarCNNModel, ConvNet1D,
+                                          ConvNet1DTF, LeNet, LeNetTF,
+                                          TitanicSimpleTFModel,
+                                          TitanicSimpleTorchModel)
+from sklearn.model_selection import train_test_split
+from transformers import (AutoModelForSequenceClassification, AutoTokenizer,
+                          set_seed)
 
 CIFAR_IMAGE_SIZE = 32
 MNIST_IMAGE_SIZE = 28
 BATCH_SIZE = 124
 MINI_BATCH_SIZE = 8
+RANDOM_SEED = 42
+
+set_seed(42)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -234,6 +234,29 @@ def load_mnist_model_softmax():
         torch.nn.Softmax(),
     )
     return model
+
+
+@pytest.fixture(scope="session", autouse=True)
+def load_hf_distilbert_sequence_classifier():
+    """
+    TODO
+    """
+    DISTILBERT_BASE = "distilbert-base-uncased"
+    model = AutoModelForSequenceClassification.from_pretrained(
+        DISTILBERT_BASE, cache_dir="/tmp/"
+    )
+    return model
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_hf_text():
+    """
+    TODO
+    """
+    DISTILBERT_BASE = "distilbert-base-uncased"
+    REFERENCE_TEXT = "The quick brown fox jumps over the lazy dog"
+    tokenizer = AutoTokenizer.from_pretrained(DISTILBERT_BASE, cache_dir="/tmp/")
+    return tokenizer(REFERENCE_TEXT, return_tensors="pt")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,9 @@ BATCH_SIZE = 124
 MINI_BATCH_SIZE = 8
 RANDOM_SEED = 42
 
-set_seed(42)
+@pytest.fixture(scope='function', autouse=True)
+def reset_prngs():
+    set_seed(42)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -236,7 +238,7 @@ def load_mnist_model_softmax():
     return model
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session", autouse=False)
 def load_hf_distilbert_sequence_classifier():
     """
     TODO
@@ -248,8 +250,8 @@ def load_hf_distilbert_sequence_classifier():
     return model
 
 
-@pytest.fixture(scope="session", autouse=True)
-def mock_hf_text():
+@pytest.fixture(scope="session", autouse=False)
+def dummy_hf_tokenizer():
     """
     TODO
     """

--- a/tests/functions/test_pytorch_model.py
+++ b/tests/functions/test_pytorch_model.py
@@ -250,17 +250,17 @@ def test_add_mean_shift_to_first_layer(load_mnist_model):
     [
         (
             lazy_fixture("load_hf_distilbert_sequence_classifier"),
-            lazy_fixture("mock_hf_text"),
+            lazy_fixture("dummy_hf_tokenizer"),
             False,
             {},
-            nullcontext(np.array([[0.01157812, 0.03933399]])),
+            nullcontext(np.array([[0.00424026, -0.03878461]])),
         ),
         (
             lazy_fixture("load_hf_distilbert_sequence_classifier"),
-            lazy_fixture("mock_hf_text"),
+            lazy_fixture("dummy_hf_tokenizer"),
             False,
             {"labels": torch.tensor([1]), "output_hidden_states": True},
-            nullcontext(np.array([[0.01157812, 0.03933399]])),
+            nullcontext(np.array([[0.00424026, -0.03878461]])),
         ),
         (
             lazy_fixture("load_hf_distilbert_sequence_classifier"),
@@ -268,14 +268,14 @@ def test_add_mean_shift_to_first_layer(load_mnist_model):
                 102]]), 'attention_mask': torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]])},
             False,
             {"labels": torch.tensor([1]), "output_hidden_states": True},
-            nullcontext(np.array([[0.01157812, 0.03933399]])),
+            nullcontext(np.array([[0.00424026, -0.03878461]])),
         ),
         (
             lazy_fixture("load_hf_distilbert_sequence_classifier"),
-            lazy_fixture("mock_hf_text"),
+            lazy_fixture("dummy_hf_tokenizer"),
             True,
             {},
-            nullcontext(np.array([[0.49306148, 0.5069385]])),
+            nullcontext(np.array([[0.51075452, 0.4892454]])),
         ),
         (
             lazy_fixture("load_hf_distilbert_sequence_classifier"),

--- a/tests/functions/test_pytorch_model.py
+++ b/tests/functions/test_pytorch_model.py
@@ -245,17 +245,19 @@ def test_add_mean_shift_to_first_layer(load_mnist_model):
 
 @pytest.mark.pytorch_model
 @pytest.mark.parametrize(
-    "hf_model,data,model_kwargs,expected",
+    "hf_model,data,softmax,model_kwargs,expected",
     [
         (
             lazy_fixture("load_hf_distilbert_sequence_classifier"),
             lazy_fixture("mock_hf_text"),
+            False,
             {},
             np.array([[0.01157812, 0.03933399]]),
         ),
         (
             lazy_fixture("load_hf_distilbert_sequence_classifier"),
             lazy_fixture("mock_hf_text"),
+            False,
             {"labels": torch.tensor([1]), "output_hidden_states": True},
             np.array([[0.01157812, 0.03933399]]),
         ),
@@ -263,19 +265,28 @@ def test_add_mean_shift_to_first_layer(load_mnist_model):
             lazy_fixture("load_hf_distilbert_sequence_classifier"),
             {'input_ids': torch.tensor([[  101,  1996,  4248,  2829,  4419, 14523,  2058,  1996, 13971,  3899,
                 102]]), 'attention_mask': torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]])},
+            False,
             {"labels": torch.tensor([1]), "output_hidden_states": True},
             np.array([[0.01157812, 0.03933399]]),
         ),
         (
             lazy_fixture("load_hf_distilbert_sequence_classifier"),
+            lazy_fixture("mock_hf_text"),
+            True,
+            {},
+            np.array([[0.49306148, 0.5069385]]),
+        ),
+        (
+            lazy_fixture("load_hf_distilbert_sequence_classifier"),
             np.array([1, 2, 3]),
+            False,
             {},
             ValueError,
         ),
     ],
 )
-def test_huggingface_classifier_predict(hf_model, data, model_kwargs, expected):
-    model = PyTorchModel(model=hf_model, model_predict_kwargs=model_kwargs)
+def test_huggingface_classifier_predict(hf_model, data, softmax, model_kwargs, expected):
+    model = PyTorchModel(model=hf_model, softmax=softmax, model_predict_kwargs=model_kwargs)
     if expected is ValueError:
         with pytest.raises(expected):
             out = model.predict(x=data)

--- a/tests/functions/test_pytorch_model.py
+++ b/tests/functions/test_pytorch_model.py
@@ -261,6 +261,13 @@ def test_add_mean_shift_to_first_layer(load_mnist_model):
         ),
         (
             lazy_fixture("load_hf_distilbert_sequence_classifier"),
+            {'input_ids': torch.tensor([[  101,  1996,  4248,  2829,  4419, 14523,  2058,  1996, 13971,  3899,
+                102]]), 'attention_mask': torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]])},
+            {"labels": torch.tensor([1]), "output_hidden_states": True},
+            np.array([[0.01157812, 0.03933399]]),
+        ),
+        (
+            lazy_fixture("load_hf_distilbert_sequence_classifier"),
             np.array([1, 2, 3]),
             {},
             ValueError,

--- a/tox.ini
+++ b/tox.ini
@@ -66,3 +66,7 @@ python =
     3.9 = py39
     3.10 = py310
     3.11 = py311
+
+[flake8]
+max-line-length = 127
+max-complexity = 10


### PR DESCRIPTION
### Description
- This PR adds an initial implementation for the HuggingFace SequenceClassification model with some initial functionality. I also organized imports using [isort](https://pypi.org/project/isort/) and made a few adjustments to increase flake8 compliance

This should be taken as an initial step toward: #238, #103, and #217 

### Implemented changes
- Insert a description of the changes implemented in the pull request.
  - [x] Modify the `PyTorchModel` prediction method to accept the HuggingFace model
  - [x] Adds new tests that prove new feature
  - [x] Add flake8 parametrization to tox 
  - [x] Modify some import ordering according to `isort`

### Minimum acceptance criteria
- Specify what is necessary for the PR to be merged with the main branch.
- @mentions of the person that is apt to review these changes, e.g., @annahedstroem
