### PR TITLE
* drop py37 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
     steps:
       - uses: actions/checkout@v3
       - name: Setup python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Launch Tutorials](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/understandable-machine-intelligence-lab/Quantus/HEAD?labpath=tutorials)
 [![Python package](https://github.com/understandable-machine-intelligence-lab/Quantus/actions/workflows/python-package.yml/badge.svg)](https://github.com/understandable-machine-intelligence-lab/Quantus/actions/workflows/python-package.yml)
 [![Code coverage](https://github.com/understandable-machine-intelligence-lab/Quantus/actions/workflows/codecov.yml/badge.svg)](https://github.com/understandable-machine-intelligence-lab/Quantus/actions/workflows/codecov.yml)
-![Python version](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue.svg)
+![Python version](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue.svg)
 [![PyPI version](https://badge.fury.io/py/quantus.svg)](https://badge.fury.io/py/quantus)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Documentation Status](https://readthedocs.org/projects/quantus/badge/?version=latest)](https://quantus.readthedocs.io/en/latest/?badge=latest)
@@ -25,11 +25,12 @@ _Quantus is currently under active development so carefully note the Quantus rel
 
 - If you want to contribute/ improve/ extend Quantus, join our [Discord](https://discord.gg/HB77krUE)!
 - New metrics added: [EfficientMPRT](https://github.com/understandable-machine-intelligence-lab/Quantus/blob/main/quantus/metrics/randomisation/efficient_mprt.py) and [SmoothMPRT](https://github.com/understandable-machine-intelligence-lab/Quantus/blob/main/quantus/metrics/randomisation/smooth_mprt.py) by [Hedström et al., (2023)](https://openreview.net/pdf?id=vVpefYmnsG)
-- Released a new version [here](https://github.com/understandable-machine-intelligence-lab/Quantus/releases) but note, support for Python 3.7 will be discontinued in future releases (https://devguide.python.org/versions/)
+- Released a new version [here](https://github.com/understandable-machine-intelligence-lab/Quantus/releases)
 - Accepted to Journal of Machine Learning Research (MLOSS), read the [paper](https://jmlr.org/papers/v24/22-0142.html)
 - Offers more than **30+ metrics in 6 categories** for XAI evaluation
 - Supports different data types (image, time-series, tabular, NLP next up!) and models (PyTorch, TensorFlow)
 - Extended built-in support for explanation methods ([captum](https://captum.ai/), [tf-explain](https://tf-explain.readthedocs.io/en/latest/) and [zennit](https://github.com/chr5tphr/zennit))
+- ❌ Discontinued support for Python 3.7 (https://devguide.python.org/versions/)
 
 ## Citation
 
@@ -189,13 +190,13 @@ pip install "quantus[tensorflow]"
 
 The package requirements are as follows:
 ```
-python>=3.7.0
+python>=3.8.0
 torch>=1.11.0
 tensorflow>=2.5.0
 ```
 
 Please note that the exact [PyTorch](https://pytorch.org/) and/ or [TensorFlow](https://www.TensorFlow.org) versions
-to be installed depends on your Python version (3.7-3.11) and platform (`darwin`, `linux`, …).
+to be installed depends on your Python version (3.8-3.11) and platform (`darwin`, `linux`, …).
 See `[project.optional-dependencies]` section in the `pyproject.toml` file.
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -25,12 +25,11 @@ _Quantus is currently under active development so carefully note the Quantus rel
 
 - If you want to contribute/ improve/ extend Quantus, join our [Discord](https://discord.gg/HB77krUE)!
 - New metrics added: [EfficientMPRT](https://github.com/understandable-machine-intelligence-lab/Quantus/blob/main/quantus/metrics/randomisation/efficient_mprt.py) and [SmoothMPRT](https://github.com/understandable-machine-intelligence-lab/Quantus/blob/main/quantus/metrics/randomisation/smooth_mprt.py) by [Hedström et al., (2023)](https://openreview.net/pdf?id=vVpefYmnsG)
-- Released a new version [here](https://github.com/understandable-machine-intelligence-lab/Quantus/releases)
+- Released a new version [here](https://github.com/understandable-machine-intelligence-lab/Quantus/releases) with [Python 3.7 discontinued](https://devguide.python.org/versions/)
 - Accepted to Journal of Machine Learning Research (MLOSS), read the [paper](https://jmlr.org/papers/v24/22-0142.html)
 - Offers more than **30+ metrics in 6 categories** for XAI evaluation
 - Supports different data types (image, time-series, tabular, NLP next up!) and models (PyTorch, TensorFlow)
 - Extended built-in support for explanation methods ([captum](https://captum.ai/), [tf-explain](https://tf-explain.readthedocs.io/en/latest/) and [zennit](https://github.com/chr5tphr/zennit))
-- ❌ Discontinued support for Python 3.7 (https://devguide.python.org/versions/)
 
 ## Citation
 

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -75,10 +75,10 @@ pip install "quantus[full]"
 
 The package requirements are as follows:
 ```
-python>=3.7.0
+python>=3.8.0
 torch>=1.11.0
 tensorflow>=2.5.0
 ```
 Please note that the exact [PyTorch](https://pytorch.org/) and/ or [TensorFlow](https://www.TensorFlow.org) versions 
-to be installed depends on your Python version (3.7-3.11) and platform (`darwin`, `linux`, …). 
+to be installed depends on your Python version (3.8-3.11) and platform (`darwin`, `linux`, …). 
 See `[project.optional-dependencies]` section in the `pyproject.toml` file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ torch = [
     "torchvision>=0.15.1; sys_platform == 'linux' and python_version >= '3.11'",
 ]
 tensorflow = [
-    # 2.16 is shipeed without keras
+    # 2.16 is shipped without keras
     "tensorflow<2.16.0",
     # keras V3 broke everything
     "keras<3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,5 +96,5 @@ tests = [
 
 
 [build-system]
-requires = ["flit-core >= 3.9"]
-build-backend = "flit_core.buildapi"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ name = "quantus"
 # https://www.python.org/dev/peps/pep-0440/
 description = "A metrics toolkit to evaluate neural network explanations."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = { file = "LICENSE" }
 keywords = ["explainable ai", "xai", "machine learning", "deep learning"]
 authors = [
@@ -28,15 +28,13 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.19.5",
-    "pandas<=1.3.3; python_version == '3.7'",
-    "pandas>=1.5.3; python_version > '3.7'",
+    "pandas>=1.5.3",
     "opencv-python>=4.5.5.62",
     "scikit-image>=0.19.3",
     "scikit-learn>=0.24.2",
     "scipy>=1.7.3",
     "tqdm>=4.62.3",
     "matplotlib>=3.3.4",
-    "typing_extensions; python_version <= '3.8'",
     "cachetools",
 ]
 
@@ -53,21 +51,18 @@ dynamic = ["version"]
 #
 [project.optional-dependencies]
 torch = [
-    "torch<=1.11.0; python_version == '3.7'",
-    "torch>=1.13.1; sys_platform != 'linux' and python_version > '3.7'",
-    "torch>=1.13.1, <2.0.0; sys_platform == 'linux' and python_version > '3.7' and python_version <= '3.10'",
+    "torch>=1.13.1; sys_platform != 'linux'",
+    "torchvision>=0.15.1; sys_platform != 'linux'",
+    "torch>=1.13.1, <2.0.0; sys_platform == 'linux' and python_version <= '3.10'",
+    "torchvision>=0.14.0, <0.15.1; sys_platform == 'linux' and python_version <= '3.10'",
     "torch>=2.0.0; sys_platform == 'linux' and python_version >= '3.11'",
-    "torchvision<=0.12.0; python_version == '3.7'",
-    "torchvision>=0.15.1; sys_platform != 'linux' and python_version > '3.7'",
-    "torchvision>=0.14.0, <0.15.1; sys_platform == 'linux' and python_version > '3.7' and python_version <= '3.10'",
     "torchvision>=0.15.1; sys_platform == 'linux' and python_version >= '3.11'",
-    "transformers<=4.30.2; python_version == '3.7'",
-    "transformers>=4.38.2; python_version > '3.7'",
 ]
 tensorflow = [
-    "tensorflow>=2.5.0; python_version == '3.7'",
-    "tensorflow>=2.12.0; sys_platform != 'darwin' and python_version > '3.7'",
-    "tensorflow_macos>=2.9.0; sys_platform == 'darwin' and python_version > '3.7'",
+    # 2.16 is shipeed without keras
+    "tensorflow<2.16.0",
+    # keras V3 broke everything
+    "keras<3"
 ]
 captum = [
     "quantus[torch]",
@@ -82,40 +77,24 @@ zennit = [
     "zennit>=0.5.1"
 ]
 transformers = [
-    "quantus[torch, tensorflow]",
-    "transformers<=4.30.2; python_version == '3.7'",
-    "transformers>=4.38.2; python_version > '3.7'",
+    "quantus[torch]",
+    "transformers>=4.38.2",
+]
+full = [
+    "quantus[captum,tf_explain,zennit,transformers]"
 ]
 tests = [
-    "captum>=0.6.0",
     "coverage>=7.2.3",
-    "flake8<=4.0.1; python_version == '3.7'",
-    "flake8>=6.0.0; python_version > '3.7'",
+    "flake8>=6.0.0",
     "pytest<=7.4.4",
     "pytest-cov>=4.0.0",
     "pytest-lazy-fixture>=0.6.3",
     "pytest-mock==3.10.0",
     "pytest_xdist",
-    "tf-explain>=0.3.1",
-    "keras<3",
-    "zennit>=0.4.5; python_version >= '3.7'",
-    "tensorflow>=2.5.0; python_version == '3.7'",
-    "tensorflow>=2.12.0; sys_platform != 'darwin' and python_version > '3.7'",
-    "tensorflow_macos>=2.9.0; sys_platform == 'darwin' and python_version > '3.7'",
-    "torch<=1.9.0; python_version == '3.7'",
-    "torch>=1.13.1; sys_platform != 'linux' and python_version > '3.7'",
-    "torch>=1.13.1, <2.0.0; sys_platform == 'linux' and python_version > '3.7' and python_version <= '3.10'",
-    "torch>=2.0.0; sys_platform == 'linux' and python_version >= '3.11'",
-    "torchvision<=0.12.0; python_version == '3.7'",
-    "torchvision>=0.15.1; sys_platform != 'linux' and python_version > '3.7'",
-    "torchvision>=0.14.0, <0.15.1; sys_platform == 'linux' and python_version > '3.7' and python_version <= '3.10'",
-    "torchvision>=0.15.1; sys_platform == 'linux' and python_version >= '3.11'",
-    "quantus[captum,tf_explain,zennit, transformers]"
-]
-full = [
-    "quantus[captum,tf_explain,zennit, transformers]"
+    "quantus[full]"
 ]
 
+
 [build-system]
-requires = ["flit-core >= 3.4"]
+requires = ["flit-core >= 3.9"]
 build-backend = "flit_core.buildapi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ captum = [
     "quantus[torch]",
     "captum>=0.6.0"
 ]
-tf_explain = [
+tf-explain = [
     "quantus[tensorflow]",
     "tf-explain>=0.3.1"
 ]
@@ -81,7 +81,7 @@ transformers = [
     "transformers>=4.38.2",
 ]
 full = [
-    "quantus[captum,tf_explain,zennit,transformers]"
+    "quantus[captum,tf-explain,zennit,transformers]"
 ]
 tests = [
     "coverage>=7.2.3",
@@ -94,10 +94,6 @@ tests = [
     "quantus[full]"
 ]
 
-
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.version]
-path = "quantus/__init__.py"
+requires = ["flit-core >= 3.4"]
+build-backend = "flit_core.buildapi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,3 +98,6 @@ tests = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "quantus/__init__.py"

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4.2
     virtualenv>20.2
 env_list =
-    py{311, 310, 39, 38, 37}
+    py{311, 310, 39, 38}
 skip_missing_interpreters = true
 
 [testenv]
@@ -61,7 +61,6 @@ commands =
 
 [gh]
 python =
-    3.7 = py37
     3.8 = py38
     3.9 = py39
     3.10 = py310


### PR DESCRIPTION
### Description
- Remove py3.7 support
- https://github.com/understandable-machine-intelligence-lab/Quantus/issues/302
- Additionally, e.g. running `pip install .[tests]` would print 
```
WARNING: quantus 0.5.3 does not provide the extra 'tf-explain'
```
changing the marker from `tf_explain` to `tf-explain` solved the issue, however I don't have an explanation why it has occurred in the first place 🤷 

### Implemented changes
- [x] Removed py3.7 from actions and `pyproject.toml`
- [x] re-arranged dependecies a bit, so we specify each library only once, and then refer to it through features flags
 - [x] ~~for some reason, `flit-core` had problems resolving self-referential optional dependecies. E.g., running `pip install .[tests]` would print "quantus has no extra tf_explain", so I swaped it for [hatchling](https://pypi.org/project/hatchling/) which worked like a charm.~~
