### PR TITLE
Fix warning filter in normalise_func.py

### DIFF
--- a/quantus/functions/normalise_func.py
+++ b/quantus/functions/normalise_func.py
@@ -108,7 +108,7 @@ def normalise_by_negative(
     # TODO: Temporary solution to catch an elusive bug causing a numpy RuntimeWarning below.
     #       Will be removed once bug is fixed.
     with warnings.catch_warnings():
-        warnings.filterwarnings("error")
+        warnings.filterwarnings("error", category=RuntimeWarning)
         try:
             return_array = np.where(
                 np.logical_and(a_min < 0.0, a_max > 0.0),


### PR DESCRIPTION
### Description
- Adjust the warning filter in normalise_func.py to only handle RuntimeWarning, which is the Warning catched later. All other Warnings can be handled by the user of the library as they wish
- Fixes #371 
- This allows usage of this library and the tutorials with numpy 2.4 (probably also since 2.0)

### Implemented changes
- Insert a description of the changes implemented in the pull request.
  - [ ] Make warning filter only error on RuntimeWarning

### Minimum acceptance criteria
- Verify that there are no other places where this warning filtering is done
- @annahedstroem
