### PR TITLE
Fix shape mismatch error in ROAD

### DIFF
--- a/quantus/metrics/faithfulness/road.py
+++ b/quantus/metrics/faithfulness/road.py
@@ -313,14 +313,9 @@ class ROAD(Metric[List[float]]):
         scores_batch:
             The evaluation results.
         """
-        # Prepare shapes. Expand a_batch if not the same shape
-        if x_batch.shape != a_batch.shape:
-            a_batch = np.broadcast_to(a_batch, x_batch.shape)
-
         # Flatten the attributions.
         batch_size = a_batch.shape[0]
         a_batch = a_batch.reshape(batch_size, -1)
-        n_features = a_batch.shape[-1]
 
         # Get indices of sorted attributions (descending).
         ordered_indices = np.argsort(-a_batch, axis=1)


### PR DESCRIPTION
### Description
`ROAD` gives shape mismatch error, that I encountered during my experimentation, due to incorrect broadcasting of `(B,H,W)` sized attributions to `(B,C,H,W)` sized input images. This is a very minor PR and Fixes #368 

I haven't added the option to decide whether to impute pixels or single color channel values as the issue requested because the rest of the repository and the wider AI community attributes pixels. This can of course be a further dicussion.

### Implemented changes
  - [x] Removed `np.broadcast_to` operation
  - [x] Removed `n_features` as it is not used in the `evaluate_batch` member function of `ROAD`

### Minimum acceptance criteria
- All tests passing
- @annahedstroem 

PS: Thank you to the maintainers and contributors for developing this package - it has been extremely useful in my research :)
